### PR TITLE
fix(react-query): `graphql-request@5.1.x` compat

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "dotansimha/graphql-code-generator"
+      "repo": "dotansimha/graphql-code-generator-community"
     }
   ],
   "snapshot": {

--- a/.changeset/shy-timers-lay.md
+++ b/.changeset/shy-timers-lay.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Fix compatibility of graphql-request fetcher with >5.0

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -14,11 +14,11 @@ export class GraphQLRequestClientFetcher implements FetcherRenderer {
 
   generateFetcherImplementaion(): string {
     return `
-function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
+function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
   return async (): Promise<TData> => client.request({
     document: query,
     variables,
-    headers
+    requestHeaders
   });
 }`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -14,8 +14,12 @@ export class GraphQLRequestClientFetcher implements FetcherRenderer {
 
   generateFetcherImplementaion(): string {
     return `
-function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
-  return async (): Promise<TData> => client.request<TData, TVariables>(query, variables, headers);
+function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
+  return async (): Promise<TData> => client.request({
+    document: query,
+    variables,
+    headers
+  });
 }`;
   }
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -584,9 +584,12 @@ export const useTestMutation = <
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
       expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
       expect(out.prepend[3])
-        .toBeSimilarStringTo(`    function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
-          return async (): Promise<TData> => client.request<TData, TVariables>(query, variables, headers);
-        }`);
+        .toBeSimilarStringTo(`    function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
+           return async (): Promise<TData> => client.request({
+             document: query,
+             variables,
+             headers
+          `);
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
       TData = TTestQuery,
       TError = unknown

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -584,11 +584,11 @@ export const useTestMutation = <
       expect(out.prepend).toContain(`import { GraphQLClient } from 'graphql-request';`);
       expect(out.prepend).toContain(`import { RequestInit } from 'graphql-request/dist/types.dom';`);
       expect(out.prepend[3])
-        .toBeSimilarStringTo(`    function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
+        .toBeSimilarStringTo(`    function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
            return async (): Promise<TData> => client.request({
              document: query,
              variables,
-             headers
+             requestHeaders
           `);
       expect(out.content).toBeSimilarStringTo(`export const useTestQuery = <
       TData = TTestQuery,


### PR DESCRIPTION
Related to https://github.com/dotansimha/graphql-code-generator/issues/8346