### PR TITLE
feat(react-query): expose "rootKey"

### DIFF
--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -72,7 +72,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
     ) =>{
     ${implHookOuter}
     return ${hookConfig.infiniteQuery.hook}<${operationResultType}, TError, TData>(
-      ${generateInfiniteQueryKey(node, hasRequiredVariables)},
+      ${generateInfiniteQueryKey(operationName, hasRequiredVariables)},
       ${impl},
       options
     )};`;
@@ -107,7 +107,7 @@ export class CustomMapperFetcher implements FetcherRenderer {
       ${options}
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node, hasRequiredVariables)},
+      ${generateQueryKey(operationName, hasRequiredVariables)},
       ${impl},
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -82,7 +82,7 @@ ${this.getFetchParams()}
       ${options}
     ) =>
     ${hookConfig.infiniteQuery.hook}<${operationResultType}, TError, TData>(
-      ${generateInfiniteQueryKey(node, hasRequiredVariables)},
+      ${generateInfiniteQueryKey(operationName, hasRequiredVariables)},
       (metaData) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
       options
     );`;
@@ -111,7 +111,7 @@ ${this.getFetchParams()}
       ${options}
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node, hasRequiredVariables)},
+      ${generateQueryKey(operationName, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -60,7 +60,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       ${options}
     ) =>
     ${hookConfig.infiniteQuery.hook}<${operationResultType}, TError, TData>(
-      ${generateInfiniteQueryKey(node, hasRequiredVariables)},
+      ${generateInfiniteQueryKey(operationName, hasRequiredVariables)},
       (metaData) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
       options
     );`;
@@ -90,7 +90,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
       ${options}
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node, hasRequiredVariables)},
+      ${generateQueryKey(operationName, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, variables),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -85,7 +85,7 @@ function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variab
       headers?: RequestInit['headers']
     ) =>
     ${hookConfig.query.hook}<${operationResultType}, TError, TData>(
-      ${generateQueryKey(node, hasRequiredVariables)},
+      ${generateQueryKey(operationName, hasRequiredVariables)},
       fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, variables, headers),
       options
     );`;

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -6,27 +6,53 @@ export function generateQueryVariablesSignature(
 ): string {
   return `variables${hasRequiredVariables ? '' : '?'}: ${operationVariablesTypes}`;
 }
-export function generateInfiniteQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
-  if (hasRequiredVariables) return `['${node.name.value}.infinite', variables]`;
-  return `variables === undefined ? ['${node.name.value}.infinite'] : ['${node.name.value}.infinite', variables]`;
+
+function generateRootInifniteQueryKey(node: OperationDefinitionNode) {
+  return `'${node.name.value}.infinite'`;
+}
+
+function generateInfiniteRootQueryKeyReference(operationName: string) {
+  return `useInfinite${operationName}.rootKey`;
+}
+
+export function generateInfiniteQueryRootKeyMaker(node: OperationDefinitionNode, operationName: string) {
+  return `\nuseInfinite${operationName}.rootKey = ${generateRootInifniteQueryKey(node)}`;
+}
+
+export function generateInfiniteQueryKey(operationName: string, hasRequiredVariables: boolean): string {
+  const rootQueryKey = generateInfiniteRootQueryKeyReference(operationName);
+  if (hasRequiredVariables) return `[${rootQueryKey}, variables]`;
+  return `variables === undefined ? [${rootQueryKey}] : [${rootQueryKey}, variables]`;
 }
 
 export function generateInfiniteQueryKeyMaker(
-  node: OperationDefinitionNode,
   operationName: string,
   operationVariablesTypes: string,
   hasRequiredVariables: boolean
 ) {
   const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
   return `\nuseInfinite${operationName}.getKey = (${signature}) => ${generateInfiniteQueryKey(
-    node,
+    operationName,
     hasRequiredVariables
-  )};\n`;
+  )}`;
 }
 
-export function generateQueryKey(node: OperationDefinitionNode, hasRequiredVariables: boolean): string {
-  if (hasRequiredVariables) return `['${node.name.value}', variables]`;
-  return `variables === undefined ? ['${node.name.value}'] : ['${node.name.value}', variables]`;
+function generateRootQueryKey(node: OperationDefinitionNode) {
+  return `'${node.name.value}'`;
+}
+
+function generateRootQueryKeyReference(operationName: string) {
+  return `use${operationName}.rootKey`;
+}
+
+export function generateQueryRootKeyMaker(node: OperationDefinitionNode, operationName: string) {
+  return `\nuse${operationName}.rootKey = ${generateRootQueryKey(node)}`;
+}
+
+export function generateQueryKey(operationName: string, hasRequiredVariables: boolean): string {
+  const rootQueryKey = generateRootQueryKeyReference(operationName);
+  if (hasRequiredVariables) return `[${rootQueryKey}, variables]`;
+  return `variables === undefined ? [${rootQueryKey}] : [${rootQueryKey}, variables]`;
 }
 
 export function generateQueryKeyMaker(
@@ -36,7 +62,7 @@ export function generateQueryKeyMaker(
   hasRequiredVariables: boolean
 ) {
   const signature = generateQueryVariablesSignature(hasRequiredVariables, operationVariablesTypes);
-  return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(node, hasRequiredVariables)};\n`;
+  return `\nuse${operationName}.getKey = (${signature}) => ${generateQueryKey(operationName, hasRequiredVariables)}`;
 }
 
 export function generateMutationKey(node: OperationDefinitionNode): string {
@@ -44,5 +70,5 @@ export function generateMutationKey(node: OperationDefinitionNode): string {
 }
 
 export function generateMutationKeyMaker(node: OperationDefinitionNode, operationName: string) {
-  return `\nuse${operationName}.getKey = () => ${generateMutationKey(node)};\n`;
+  return `\nuse${operationName}.getKey = () => ${generateMutationKey(node)}`;
 }

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -10,6 +10,8 @@ import {
   generateMutationKeyMaker,
   generateQueryKeyMaker,
   generateInfiniteQueryKeyMaker,
+  generateQueryRootKeyMaker,
+  generateInfiniteQueryRootKeyMaker,
 } from './variables-generator.js';
 
 import { CustomMapperFetcher } from './fetcher-custom-mapper.js';
@@ -181,6 +183,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
         query += `\nuse${operationName}.document = ${documentVariableName};\n`;
       }
       if (this.config.exposeQueryKeys) {
+        query += `\n${generateQueryRootKeyMaker(node, operationName)};\n`;
         query += `\n${generateQueryKeyMaker(node, operationName, operationVariablesTypes, hasRequiredVariables)};\n`;
       }
       if (this.config.addInfiniteQuery) {
@@ -193,8 +196,8 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<ReactQueryRawPlugin
           hasRequiredVariables
         )}\n`;
         if (this.config.exposeQueryKeys) {
+          query += `\n${generateInfiniteQueryRootKeyMaker(node, operationName)};\n`;
           query += `\n${generateInfiniteQueryKeyMaker(
-            node,
             operationName,
             operationVariablesTypes,
             hasRequiredVariables

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -25,7 +25,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
       options
     );
@@ -39,7 +39,7 @@ export const useInfiniteTestQuery = <
     ) =>{
     const query = useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument)
     return useInfiniteQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? [useInfiniteTestQuery.rootKey] : [useInfiniteTestQuery.rootKey, variables],
       (metaData) => query({...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})}),
       options
     )};
@@ -87,7 +87,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -101,7 +101,7 @@ export const useInfiniteTestQuery = <
     ) =>{
     
     return useInfiniteQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? [useInfiniteTestQuery.rootKey] : [useInfiniteTestQuery.rootKey, variables],
       (metaData) => myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
       options
     )};
@@ -149,7 +149,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -197,7 +197,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     );
@@ -249,7 +249,7 @@ export const useTestQuery = <
       headers?: RequestInit['headers']
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables, headers),
       options
     );
@@ -300,7 +300,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -347,7 +347,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -394,7 +394,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -441,7 +441,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );
@@ -488,7 +488,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TTestQuery, TError, TData>
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     );

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -78,7 +78,7 @@ export const useTestQuery = <
       options?: UseQueryOptions<TestQuery, TError, TData>
     ) =>
     useQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     );
@@ -92,7 +92,7 @@ export const useInfiniteTestQuery = <
       options?: UseInfiniteQueryOptions<TestQuery, TError, TData>
     ) =>
     useInfiniteQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? [useInfiniteTestQuery.rootKey] : [useInfiniteTestQuery.rootKey, variables],
       (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
       options
     );
@@ -254,7 +254,7 @@ export const useTestMutation = <
           options?: UseQueryOptions<TTestQuery, TError, TData>
         ) =>
         useQuery<TTestQuery, TError, TData>(
-          variables === undefined ? ['test'] : ['test', variables],
+          variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
           myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
           options
         );`);
@@ -268,7 +268,7 @@ export const useTestMutation = <
       options?: UseInfiniteQueryOptions<TTestQuery, TError, TData>
     ) =>{
     return useInfiniteQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? [useInfiniteTestQuery.rootKey] : [useInfiniteTestQuery.rootKey, variables],
       (metaData) => myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
       options
     )};`);
@@ -306,7 +306,7 @@ export const useTestMutation = <
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) =>
       useQuery<TTestQuery, TError, TData>(
-        variables === undefined ? ['test'] : ['test', variables],
+        variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
         myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
       );`);
@@ -350,7 +350,7 @@ export const useTestMutation = <
           options?: UseQueryOptions<TTestQuery, TError, TData>
         ) =>
         useQuery<TTestQuery, TError, TData>(
-          variables === undefined ? ['test'] : ['test', variables],
+          variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
           useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
           options
         );`);
@@ -365,7 +365,7 @@ export const useTestMutation = <
     ) =>{
       const query = useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument)
       return useInfiniteQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? [useInfiniteTestQuery.rootKey] : [useInfiniteTestQuery.rootKey, variables],
       (metaData) => query({...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})}),
       options
     )};`);
@@ -597,7 +597,7 @@ export const useTestMutation = <
       headers?: RequestInit['headers']
     ) =>
     useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
       fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables, headers),
       options
     );`);
@@ -791,7 +791,7 @@ export const useTestMutation = <
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) =>
       useQuery<TTestQuery, TError, TData>(
-        variables === undefined ? ['test'] : ['test', variables],
+        variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
         fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
         options
       );`);
@@ -1107,7 +1107,7 @@ export const useTestMutation = <
         options?: UseQueryOptions<TTestQuery, TError, TData>
       ) =>
       useQuery<TTestQuery, TError, TData>(
-        variables === undefined ? ['test'] : ['test', variables],
+        variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables],
         fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
         options
       );`);
@@ -1265,7 +1265,7 @@ export const useTestMutation = <
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];`
+        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables];`
       );
     });
   });
@@ -1278,11 +1278,13 @@ export const useTestMutation = <
         addInfiniteQuery: true,
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toBeSimilarStringTo(`useTestQuery.rootKey = 'test';`);
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];`
+        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? [useTestQuery.rootKey] : [useTestQuery.rootKey, variables];`
       );
+      expect(out.content).toBeSimilarStringTo(`useInfiniteTestQuery.rootKey = 'test.infinite';`);
       expect(out.content).toBeSimilarStringTo(
-        `useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite'] : ['test.infinite', variables];`
+        `useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? [useInfiniteTestQuery.rootKey] : [useInfiniteTestQuery.rootKey, variables];`
       );
     });
   });


### PR DESCRIPTION
## Description

This PR 

Related # 13

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS: mac Monterey 12.4
- NodeJS: 16.17.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This PR introduces and exposes a `.rootKey` value on the hook, to allow flexibility in accessing the static query keys of the generated functions. See discussions in #18 

For example, you can now easily invalidate all the queries of your hook with:

```ts
queryClient.invalidateQueries({ queryKey: [useMyQuery.rootKey] })
```