### PR TITLE
feat(near-operation-file-preset): override filename

### DIFF
--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -3,7 +3,7 @@ import type { Source } from '@graphql-tools/utils';
 import addPlugin from '@graphql-codegen/add';
 import { join } from 'path';
 import { FragmentDefinitionNode, buildASTSchema, GraphQLSchema, DocumentNode, Kind } from 'graphql';
-import { appendExtensionToFilePath, defineFilepathSubfolder } from './utils.js';
+import { appendFileNameToFilePath, defineFilepathSubfolder } from './utils.js';
 import { resolveDocumentImports, DocumentImportResolverOptions } from './resolve-document-imports.js';
 import {
   FragmentImport,
@@ -73,6 +73,30 @@ export type NearOperationFileConfig = {
    * ```
    */
   importAllFragmentsFrom?: string | FragmentImportFromFn;
+  /**
+   * @description Optional, sets a specfic file name for the generated files. Use this to override the generated file name when generating files for example based on mutliple .graphql files.
+   *
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts" {11}
+   *  import type { CodegenConfig } from '@graphql-codegen/cli';
+   *
+   *  const config: CodegenConfig = {
+   *    // ...
+   *    generates: {
+   *      'path/to/file.ts': {
+   *        preset: 'near-operation-file',
+   *        plugins: ['typescript-operations', 'typescript-react-apollo'],
+   *        presetConfig: {
+   *          baseTypesPath: 'types.ts',
+   *          fileName: 'index',
+   *        },
+   *      },
+   *    },
+   *  };
+   *  export default config;
+   * ```
+   */
+  fileName?: string;
   /**
    * @description Optional, sets the extension for the generated files. Use this to override the extension if you are using plugins that requires a different type of extensions (such as `typescript-react-apollo`)
    * @default .generated.ts
@@ -185,6 +209,7 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
       ? options.schemaAst
       : buildASTSchema(options.schema, options.config as any);
     const baseDir = options.presetConfig.cwd || process.cwd();
+    const fileName = options.presetConfig.fileName;
     const extension = options.presetConfig.extension || '.generated.ts';
     const folder = options.presetConfig.folder || '';
     const importTypesNamespace = options.presetConfig.importTypesNamespace || 'Types';
@@ -214,7 +239,7 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
         generateFilePath(location: string) {
           const newFilePath = defineFilepathSubfolder(location, folder);
 
-          return appendExtensionToFilePath(newFilePath, extension);
+          return appendFileNameToFilePath(newFilePath, fileName, extension);
         },
         schemaTypesSource: {
           path: shouldAbsolute ? join(options.baseOutputDir, baseTypesPath) : baseTypesPath,

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -9,10 +9,11 @@ export function defineFilepathSubfolder(baseFilePath: string, folder: string) {
   return join(parsedPath.dir, folder, parsedPath.base).replace(/\\/g, '/');
 }
 
-export function appendExtensionToFilePath(baseFilePath: string, extension: string) {
+export function appendFileNameToFilePath(baseFilePath: string, fileName: string | undefined, extension: string) {
   const parsedPath = parsePath(baseFilePath);
+  const name = fileName || parsedPath.name;
 
-  return join(parsedPath.dir, parsedPath.name + extension).replace(/\\/g, '/');
+  return join(parsedPath.dir, name + extension).replace(/\\/g, '/');
 }
 
 export function extractExternalFragmentsInUse(

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -725,6 +725,29 @@ describe('near-operation-file preset', () => {
     ]);
   });
 
+  it('Should allow to customize output fileName', async () => {
+    const result = await executePreset({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        cwd: '/some/deep/path',
+        baseTypesPath: 'types.ts',
+        fileName: 'index',
+        extension: '.flow.js',
+      },
+      schema: schemaDocumentNode,
+      schemaAst: schemaNode,
+      documents: testDocuments,
+      plugins: [],
+      pluginMap: {},
+    });
+
+    expect(result.map(a => a.filename)).toEqual([
+      '/some/deep/path/src/graphql/index.flow.js',
+      '/some/deep/path/src/graphql/nested/index.flow.js',
+    ]);
+  });
+
   it('Should prepend the "add" plugin with the correct import', async () => {
     const result = await executePreset({
       baseOutputDir: './src/',


### PR DESCRIPTION
## Description

Add a `fileName` option to the config of the `near-operation-file-preset` to override the file name of the generated files, similar to the `extension` option.

Related #23 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Should allow to customize output fileName (includes extension option)

**Test Environment**:

- OS: Windows 10
- `@graphql-codegen/...`: latest
- NodeJS: v16.17.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules