### PR TITLE
revert PR #8497: "fixes issue #7549"

### DIFF
--- a/.changeset/violet-jokes-repair.md
+++ b/.changeset/violet-jokes-repair.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Reverts problematic part of PR #8497. That PR fixed an issue with infinite query generated hooks not utilizing pageParamKeys for custom fetchers but in the process introduced a type error. This removes the cause of the type error.

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -475,7 +475,7 @@ export const useInfiniteCommentQuery = <TData = CommentQuery, TError = unknown>(
     metaData =>
       fetcher<CommentQuery, CommentQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, CommentDocument, {
         ...variables,
-        ...(metaData.pageParam ? { [pageParamKey]: metaData.pageParam } : {}),
+        ...(metaData.pageParam ?? {}),
       })(),
     options
   );
@@ -516,7 +516,7 @@ export const useInfiniteCurrentUserForProfileQuery = <TData = CurrentUserForProf
         dataSource.endpoint,
         dataSource.fetchParams || {},
         CurrentUserForProfileDocument,
-        { ...variables, ...(metaData.pageParam ? { [pageParamKey]: metaData.pageParam } : {}) }
+        { ...variables, ...(metaData.pageParam ?? {}) }
       )(),
     options
   );
@@ -552,7 +552,7 @@ export const useInfiniteFeedQuery = <TData = FeedQuery, TError = unknown>(
     metaData =>
       fetcher<FeedQuery, FeedQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, FeedDocument, {
         ...variables,
-        ...(metaData.pageParam ? { [pageParamKey]: metaData.pageParam } : {}),
+        ...(metaData.pageParam ?? {}),
       })(),
     options
   );

--- a/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-custom-mapper.ts
@@ -59,8 +59,8 @@ export class CustomMapperFetcher implements FetcherRenderer {
     const typedFetcher = this.getFetcherFnName(operationResultType, operationVariablesTypes);
     const implHookOuter = this._isReactHook ? `const query = ${typedFetcher}(${documentVariableName})` : '';
     const impl = this._isReactHook
-      ? `(metaData) => query({...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})`
-      : `(metaData) => ${typedFetcher}(${documentVariableName}, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})()`;
+      ? `(metaData) => query({...variables, ...(metaData.pageParam ?? {})})`
+      : `(metaData) => ${typedFetcher}(${documentVariableName}, {...variables, ...(metaData.pageParam ?? {})})()`;
 
     return `export const useInfinite${operationName} = <
       TData = ${operationResultType},

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -83,7 +83,7 @@ ${this.getFetchParams()}
     ) =>
     ${hookConfig.infiniteQuery.hook}<${operationResultType}, TError, TData>(
       ${generateInfiniteQueryKey(node, hasRequiredVariables)},
-      (metaData) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
+      (metaData) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     );`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -61,7 +61,7 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
     ) =>
     ${hookConfig.infiniteQuery.hook}<${operationResultType}, TError, TData>(
       ${generateInfiniteQueryKey(node, hasRequiredVariables)},
-      (metaData) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
+      (metaData) => fetcher<${operationResultType}, ${operationVariablesTypes}>(dataSource.endpoint, dataSource.fetchParams || {}, ${documentVariableName}, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     );`;
   }

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -54,7 +54,7 @@ function fetcher<TData, TVariables extends { [key: string]: any }>(client: Graph
     ) =>
     ${hookConfig.infiniteQuery.hook}<${operationResultType}, TError, TData>(
       ${generateInfiniteQueryKey(node, hasRequiredVariables)},
-      (metaData) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})}, headers)(),
+      (metaData) => fetcher<${operationResultType}, ${operationVariablesTypes}>(client, ${documentVariableName}, {...variables, ...(metaData.pageParam ?? {})}, headers)(),
       options
     );`;
   }

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -40,7 +40,7 @@ export const useInfiniteTestQuery = <
     const query = useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument)
     return useInfiniteQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
-      (metaData) => query({...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})}),
+      (metaData) => query({...variables, ...(metaData.pageParam ?? {})}),
       options
     )};
 
@@ -102,7 +102,7 @@ export const useInfiniteTestQuery = <
     
     return useInfiniteQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
-      (metaData) => myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
+      (metaData) => myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     )};
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -93,7 +93,7 @@ export const useInfiniteTestQuery = <
     ) =>
     useInfiniteQuery<TestQuery, TError, TData>(
       variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
-      (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
+      (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     );
 
@@ -269,7 +269,7 @@ export const useTestMutation = <
     ) =>{
     return useInfiniteQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
-      (metaData) => myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, {...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})})(),
+      (metaData) => myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     )};`);
       expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <
@@ -366,7 +366,7 @@ export const useTestMutation = <
       const query = useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument)
       return useInfiniteQuery<TTestQuery, TError, TData>(
       variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
-      (metaData) => query({...variables, ...(metaData.pageParam ? {[pageParamKey]: metaData.pageParam} : {})}),
+      (metaData) => query({...variables, ...(metaData.pageParam ?? {})}),
       options
     )};`);
       expect(out.content).toBeSimilarStringTo(`export const useTestMutation = <


### PR DESCRIPTION
## Description

PR #8497 applied a fix to an issue with infintieQueries not working for custom fetchers, but in the process broke a infiniteQueries for some of the fetchers. A hotfix for this produced a type issue for queries with no variables that is not easily solvable. See discussion [here](https://github.com/dotansimha/graphql-code-generator/pull/8567#issuecomment-1306569256).

In lieu of the ideal solution which would be to conditionally keep codegen from generating infinite query hooks for queries w/o input variables (no inputs means nothing to paginate over), the best thing to do for now is revert most of the original PR.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated the typescript-react-query plugin test suite (packages/plugins/typescript/react-query/tests/react-query.spec.ts) to match the new outputs

**Test Environment**:

- OS: Ubuntu 18.04
- NodeJS: v14.20.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
