### PR TITLE
fix(vue-apollo): default to empty options in all mutations

### DIFF
--- a/.changeset/reproduce-laundry-pause.md
+++ b/.changeset/reproduce-laundry-pause.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/vue-apollo': patch
+---
+
+Default to empty object for `options` parameter in generated mutation functions, even those with required variables.

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -648,7 +648,7 @@ export function useSubmitRepositoryMutation(
     | VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
     | ReactiveFunction<
         VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>
-      >
+      > = {}
 ) {
   return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(
     SubmitRepositoryDocument,
@@ -689,7 +689,9 @@ export const SubmitCommentDocument = gql`
 export function useSubmitCommentMutation(
   options:
     | VueApolloComposable.UseMutationOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
-    | ReactiveFunction<VueApolloComposable.UseMutationOptions<SubmitCommentMutation, SubmitCommentMutationVariables>>
+    | ReactiveFunction<
+        VueApolloComposable.UseMutationOptions<SubmitCommentMutation, SubmitCommentMutationVariables>
+      > = {}
 ) {
   return VueApolloComposable.useMutation<SubmitCommentMutation, SubmitCommentMutationVariables>(
     SubmitCommentDocument,
@@ -733,7 +735,7 @@ export const VoteDocument = gql`
 export function useVoteMutation(
   options:
     | VueApolloComposable.UseMutationOptions<VoteMutation, VoteMutationVariables>
-    | ReactiveFunction<VueApolloComposable.UseMutationOptions<VoteMutation, VoteMutationVariables>>
+    | ReactiveFunction<VueApolloComposable.UseMutationOptions<VoteMutation, VoteMutationVariables>> = {}
 ) {
   return VueApolloComposable.useMutation<VoteMutation, VoteMutationVariables>(VoteDocument, options);
 }

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -269,9 +269,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<VueApolloRawPluginCo
 }`;
       }
       case 'Mutation': {
-        return `export function use${operationName}(options: VueApolloComposable.UseMutationOptions<${operationResultType}, ${operationVariablesTypes}> | ReactiveFunction<VueApolloComposable.UseMutationOptions<${operationResultType}, ${operationVariablesTypes}>>${
-          operationHasNonNullableVariable ? '' : ' = {}'
-        }) {
+        return `export function use${operationName}(options: VueApolloComposable.UseMutationOptions<${operationResultType}, ${operationVariablesTypes}> | ReactiveFunction<VueApolloComposable.UseMutationOptions<${operationResultType}, ${operationVariablesTypes}>> = {}) {
   return VueApolloComposable.useMutation<${operationResultType}, ${operationVariablesTypes}>(${documentNodeVariable}, options);
 }`;
       }

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -734,7 +734,7 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(
-        `export function useSubmitRepositoryMutation(options: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> | ReactiveFunction<VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>>) {
+        `export function useSubmitRepositoryMutation(options: VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables> | ReactiveFunction<VueApolloComposable.UseMutationOptions<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>> = {}) {
            return VueApolloComposable.useMutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>(SubmitRepositoryDocument, options);
         }`
       );

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -37,7 +37,7 @@ describe('Vue Apollo', () => {
     }
   `);
   const mutationDoc = parse(/* GraphQL */ `
-    mutation test($name: String) {
+    mutation test($name: String!) {
       submitRepository(repoFullName: $name) {
         id
       }
@@ -1227,6 +1227,22 @@ query MyFeed {
 
       expect(content.prepend).toContain(`import * as Operations from 'path/to/documents';`);
       expect(content.content).toBeSimilarStringTo(`export function useTestMutation`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should default to an empty options object in useMutation', async () => {
+      const config: VueApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'path/to/documents.ts',
+      };
+
+      const docs = [{ location: '', document: mutationDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`>> = {}) {`);
       await validateTypeScript(content, schema, docs, {});
     });
 


### PR DESCRIPTION
... even those with required variables, as those don't have to be passed when creating the query, but only when calling `mutate`.

## Description

When you have a GraphQL mutation with non-nullable inputs, the function created by `@graphql-codegen/typescript-vue-apollo` makes the `options` parameter required instead of defaulting to an empty object `{}`.

However, you can still manually pass `{}`, since the actual variables don't have to be set in the `useAbcMutation` function, but can also be passed in the `mutate` function:

```ts
const {mutate} = useAbcMutation({}) // should default to {}

mutate({ input: 'foo' })
```

E.g. for this mutation:

```graphql
mutation Abc($input: String!) {
  updateAbc(input: $input) {
    id
  }
}
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not tested, but I think the issue is better highlighted in the PR.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules