### PR TITLE
feat: allow arrays to be generated as const

### DIFF
--- a/.changeset/curvy-balloons-play.md
+++ b/.changeset/curvy-balloons-play.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-enum-array': minor
+---
+
+Allow arrays to be generated as const.

--- a/packages/plugins/typescript/enum-array/src/config.ts
+++ b/packages/plugins/typescript/enum-array/src/config.ts
@@ -4,4 +4,8 @@ export interface EnumArrayPluginConfig {
    * if not given, omit import statement.
    */
   importFrom?: string;
+  /**
+   * @description generate the arrays as const. Defaults to false
+   */
+  constArrays?: boolean;
 }

--- a/packages/plugins/typescript/enum-array/tests/enum-array.spec.ts
+++ b/packages/plugins/typescript/enum-array/tests/enum-array.spec.ts
@@ -45,4 +45,24 @@ describe('TypeScript', () => {
       `);
     });
   });
+  describe('with constArrays', () => {
+    it('Should work', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        "custom enum"
+        enum MyEnum {
+          "this is a"
+          A
+          "this is b"
+          B
+        }
+      `);
+      const result = (await plugin(schema, [], { constArrays: true })) as Types.ComplexPluginOutput;
+
+      expect(result.prepend).toBeSimilarStringTo(`
+      `);
+      expect(result.content).toBeSimilarStringTo(`
+        const MY_ENUM = ['A', 'B'] as const;
+      `);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Allows arrays to optionally be generated `as const`.

Related #58

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have run the tests in the repo.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
