### PR TITLE
fix: typescript-vue-apollo changeset

### DIFF
--- a/.changeset/reproduce-laundry-pause.md
+++ b/.changeset/reproduce-laundry-pause.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/vue-apollo': patch
+'@graphql-codegen/typescript-vue-apollo': patch
 ---
 
 Default to empty object for `options` parameter in generated mutation functions, even those with required variables.


### PR DESCRIPTION
## Description

Fixes a typo in one of the changeset files which has been causing recent runs of the `release` workflow to fail.

https://github.com/dotansimha/graphql-code-generator-community/actions/runs/3952936440/jobs/6768627038#step:5:30

Related #45

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
