### PR TITLE
feat: support using enum members instead of string literals

### DIFF
--- a/.changeset/moody-islands-smoke.md
+++ b/.changeset/moody-islands-smoke.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-enum-array': minor
+---
+
+support using enum members instead of string literals

--- a/packages/plugins/typescript/enum-array/package.json
+++ b/packages/plugins/typescript/enum-array/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^3.0.0",
+    "@graphql-codegen/visitor-plugin-common": "2.13.7",
     "tslib": "~2.4.0"
   },
   "devDependencies": {

--- a/packages/plugins/typescript/enum-array/src/config.ts
+++ b/packages/plugins/typescript/enum-array/src/config.ts
@@ -1,4 +1,6 @@
-export interface EnumArrayPluginConfig {
+import { RawTypesConfig } from '@graphql-codegen/visitor-plugin-common';
+
+export interface EnumArrayPluginConfig extends RawTypesConfig {
   /**
    * @description import enum types from generated type path
    * if not given, omit import statement.
@@ -8,4 +10,8 @@ export interface EnumArrayPluginConfig {
    * @description generate the arrays as const. Defaults to false
    */
   constArrays?: boolean;
+  /**
+   * @description use enum members instead of string literals. Defaults to false
+   */
+  useMembers?: boolean;
 }

--- a/packages/plugins/typescript/enum-array/tests/enum-array.spec.ts
+++ b/packages/plugins/typescript/enum-array/tests/enum-array.spec.ts
@@ -65,4 +65,45 @@ describe('TypeScript', () => {
       `);
     });
   });
+  describe('with useMembers', () => {
+    it('Should work', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        "custom enum"
+        enum MyEnum {
+          "this is abc_def"
+          abc_def
+          "this is ghi_jkl"
+          ghi_jkl
+        }
+      `);
+      const result = (await plugin(schema, [], { useMembers: true })) as Types.ComplexPluginOutput;
+
+      expect(result.prepend).toBeSimilarStringTo(`
+      `);
+      expect(result.content).toBeSimilarStringTo(`
+        const MY_ENUM: MyEnum[] = [MyEnum.AbcDef, MyEnum.GhiJkl];
+      `);
+    });
+    it('respects namingConvention', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        "custom enum"
+        enum MyEnum {
+          "this is abc_def"
+          abc_def
+          "this is ghi_jkl"
+          ghi_jkl
+        }
+      `);
+      const result = (await plugin(schema, [], {
+        useMembers: true,
+        namingConvention: 'change-case-all#snakeCase',
+      })) as Types.ComplexPluginOutput;
+
+      expect(result.prepend).toBeSimilarStringTo(`
+      `);
+      expect(result.content).toBeSimilarStringTo(`
+        const MY_ENUM: my_enum[] = [my_enum.abc_def, my_enum.ghi_jkl];
+      `);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,7 +1426,7 @@
     lodash "~4.17.0"
     tslib "~2.4.0"
 
-"@graphql-codegen/plugin-helpers@^3.0.0":
+"@graphql-codegen/plugin-helpers@^3.0.0", "@graphql-codegen/plugin-helpers@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz#69a2e91178f478ea6849846ade0a59a844d34389"
   integrity sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==
@@ -1481,7 +1481,7 @@
     auto-bind "~4.0.0"
     tslib "~2.4.0"
 
-"@graphql-codegen/visitor-plugin-common@2.13.1", "@graphql-codegen/visitor-plugin-common@^2.12.1":
+"@graphql-codegen/visitor-plugin-common@2.13.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz#2228660f6692bcdb96b1f6d91a0661624266b76b"
   integrity sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==
@@ -1492,6 +1492,22 @@
     "@graphql-tools/utils" "^8.8.0"
     auto-bind "~4.0.0"
     change-case-all "1.0.14"
+    dependency-graph "^0.11.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "~2.4.0"
+
+"@graphql-codegen/visitor-plugin-common@2.13.7", "@graphql-codegen/visitor-plugin-common@^2.12.1":
+  version "2.13.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.7.tgz#591e054a970a0d572bdfb765bf948dae21bf8aed"
+  integrity sha512-xE6iLDhr9sFM1qwCGJcCXRu5MyA0moapG2HVejwyAXXLubYKYwWnoiEigLH2b5iauh6xsl6XP8hh9D1T1dn5Cw==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^3.1.2"
+    "@graphql-tools/optimize" "^1.3.0"
+    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
+    "@graphql-tools/utils" "^9.0.0"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.15"
     dependency-graph "^0.11.0"
     graphql-tag "^2.11.0"
     parse-filepath "^1.0.2"


### PR DESCRIPTION
## Description

Use enum members instead of string literals when `useMembers` is true.

Also updated to support `namingConvention`, `typesPrefix`, `typesSuffix`, and `enumPrefix`.

Related https://github.com/dotansimha/graphql-code-generator/issues/7169

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have run the tests in the repo.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
