### PR TITLE
Make typescript-generic-sdk respect importOperationTypesFrom option

### DIFF
--- a/.changeset/smooth-papayas-invent.md
+++ b/.changeset/smooth-papayas-invent.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-generic-sdk': minor
+---
+
+Make typescript-generic-sdk respect the `documentMode` external option by prefixing types with the value configured in `importOperationTypesFrom` as documented.

--- a/packages/plugins/typescript/generic-sdk/tests/generic-sdk.spec.ts
+++ b/packages/plugins/typescript/generic-sdk/tests/generic-sdk.spec.ts
@@ -231,5 +231,33 @@ async function test() {
 `);
       }
     });
+
+    it('respects importDocumentNodeExternallyFrom', async () => {
+      const config = { importDocumentNodeExternallyFrom: './operations', documentMode: DocumentMode.external };
+      const docs = [{ location: '', document: basicDoc }];
+      const result = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+      const output = await validate(result, config, docs, schema, '');
+
+      expect(output).toContain(`import * as Operations from './operations';`);
+      expect(output).toContain(`(Operations.FeedDocument, variables, options)`);
+      expect(output).toContain(`(Operations.Feed2Document, variables, options)`);
+      expect(output).toContain(`(Operations.Feed3Document, variables, options)`);
+    });
+
+    it('respects importOperationTypesFrom', async () => {
+      const config = { importOperationTypesFrom: 'Types' };
+      const docs = [{ location: '', document: basicDoc }];
+      const result = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+      const output = await validate(result, config, docs, schema, '');
+
+      expect(output).toContain(`Types.FeedQuery`);
+      expect(output).toContain(`Types.Feed2Query`);
+      expect(output).toContain(`Types.Feed3Query`);
+      expect(output).toContain(`Types.Feed4Query`);
+    });
   });
 });


### PR DESCRIPTION
## Description

Related #69

Make `typescript-generic-sdk` respect the `documentMode` `external` option by prefixing types with the value configured in `importOperationTypesFrom` as it is already documented.

## Type of change

Adapted the visitor of `typescript-generic-sdk`. Changes are heavily inspired by `typescript-graphql-request` visitor.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added the following two unit tests. Copied from `typescript-graphql-request` test suite and adapted to generic-sdk.

- [x] respects importDocumentNodeExternallyFrom
- [x] respects importOperationTypesFrom

**Test Environment**:

- OS: macOS 13
- `@graphql-codegen/typescript-generic-sdk`:
- NodeJS: 16.17.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
