### PR TITLE
fix(typescript-rtk-query): update imported api to use alternate name

### DIFF
--- a/.changeset/fifty-berries-chew.md
+++ b/.changeset/fifty-berries-chew.md
@@ -1,0 +1,24 @@
+---
+"@graphql-codegen/typescript-rtk-query": patch
+---
+
+fix: update imported api to use alternate name
+
+Previously imported api name did not update actual implementation 
+
+```
+import { newApiName } from '../baseApi'
+
+...
+const injectedApi = oldApiName...
+
+```
+
+now it does update the implementation
+
+```
+import { newApiName } from '../baseApi'
+
+...
+const injectedApi = newApiName...
+...

--- a/packages/plugins/typescript/rtk-query/src/visitor.ts
+++ b/packages/plugins/typescript/rtk-query/src/visitor.ts
@@ -63,7 +63,7 @@ export class RTKQueryVisitor extends ClientSideBaseVisitor<RTKQueryRawPluginConf
 
     return (
       `
-const injectedRtkApi = api.injectEndpoints({
+const injectedRtkApi = ${this.config.importBaseApiAlternateName}.injectEndpoints({
   ${
     !this.config.overrideExisting
       ? ''

--- a/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
+++ b/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
@@ -130,7 +130,7 @@ export const SubmitRepositoryDocument = \`
 }
     \`;
 
-const injectedRtkApi = api.injectEndpoints({
+const injectedRtkApi = alternateApiName.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
       query: (variables) => ({ document: CommentDocument, variables })


### PR DESCRIPTION
## Description
Previously I created a [PR](https://github.com/dotansimha/graphql-code-generator-community/pull/75) to allow the imported api name to be changed, however I forgot to change the actual implementation to use the new name. This PR does this:

```
import { newApiName } from '../baseApi'

...
const injectedApi = newApiName...
...
```

Related # (issue)
https://github.com/dotansimha/graphql-code-generator-community/issues/68

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Updated the snapshot for the relevant test to show the updated import implementation

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules