### PR TITLE
feat: Nhost typescript plugin

### DIFF
--- a/.changeset/tender-bulldogs-burn.md
+++ b/.changeset/tender-bulldogs-burn.md
@@ -6,6 +6,11 @@ Initial release
 
 The `typescript-nhost` plugin generates the schema for the [`Typescript Nhost SDK`](https://docs.nhost.io/reference/javascript).
 
+What the plugin does:
+- Generate types with `graphql-codegem/typescript`, following a strict configuration. (the plugin does not require `@graphql-codegen/typescript` to be installed by the user but is use as a dependency).
+- Minify the introspection object with `'@urql/introspection`
+- Export the introspection object as well as all the types so they can be accessed through a default `import schema from './generated-schema'`
+
 ### Installation
 
 ```sh

--- a/.changeset/tender-bulldogs-burn.md
+++ b/.changeset/tender-bulldogs-burn.md
@@ -1,0 +1,47 @@
+---
+'@graphql-codegen/typescript-nhost': patch
+---
+
+Initial release
+
+The `typescript-nhost` plugin generates the schema for the [`Typescript Nhost SDK`](https://docs.nhost.io/reference/javascript).
+
+### Installation
+
+```sh
+yarn add -D @graphql-codegen/cli @graphql-codegen/typescript-nhost
+```
+
+Then configure the code generator by adding a `codegen.yaml` file:
+
+```yaml filename="codegen.yaml"
+schema:
+  - http://localhost:1337/v1/graphql:
+      headers:
+        x-hasura-admin-secret: nhost-admin-secret
+generates:
+  ./src/schema.ts:
+    plugins:
+      - typescript-nhost
+```
+
+### Usage
+
+```sh
+yarn add @nhost/nhost-js
+```
+
+```ts filename="src/main.ts"
+import { NhostClient } from '@nhost/nhost-js';
+import schema from './schema';
+
+const nhost = new NhostClient({ subdomain: 'localhost', schema });
+```
+
+A GraphQL query named `todos` will then be accessible through:
+
+```ts
+const todos = await nhost.graphql.query.todos({ select: { contents: true } });
+```
+
+The `todos` object will be strongly typed based on the GraphQL schema, and the fields that would have been selected in the query.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository is owned by the GraphQL Code Generator community and is home to 
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Fcli.svg)](htflow-operationss://badge.fury.io/js/%40graphql-codegen%2Fflow-operations) - `@graphql-codegen/flow-operations`
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Fcli.svg)](httypescript-msws://badge.fury.io/js/%40graphql-codegen%2Ftypescript-msw) - `@graphql-codegen/typescript-msw`
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-mongodb.svg)](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-mongodb) - `@graphql-codegen/typescript-mongodb`
+- [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-nhost.svg)](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-nhost) - `@graphql-codegen/typescript-nhost`
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-type-graphql.svg)](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-type-graphql) - `@graphql-codegen/typescript-type-graphql`
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Fcli.svg)](htjsdocs://badge.fury.io/js/%40graphql-codegen%2Fjsdoc) - `@graphql-codegen/jsdoc`
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-vue-urql.svg)](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-vue-urql) - `@graphql-codegen/typescript-vue-urql`

--- a/packages/plugins/typescript/nhost/jest.config.js
+++ b/packages/plugins/typescript/nhost/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../../jest.project')({ dirname: __dirname });

--- a/packages/plugins/typescript/nhost/package.json
+++ b/packages/plugins/typescript/nhost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-codegen/typescript-nhost",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "GraphQL Code Generator plugin for the Typescript Nhost SDK",
   "repository": {
     "type": "git",

--- a/packages/plugins/typescript/nhost/package.json
+++ b/packages/plugins/typescript/nhost/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@graphql-codegen/typescript-nhost",
+  "version": "0.0.1",
+  "description": "GraphQL Code Generator plugin for the Typescript Nhost SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/graphql-code-generator-community.git",
+    "directory": "packages/plugins/typescript/nhost"
+  },
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint **/*.ts",
+    "test": "jest --no-watchman --config ../../../../jest.config.js"
+  },
+  "dependencies": {
+    "@graphql-codegen/plugin-helpers": "^4.0.0",
+    "@graphql-codegen/typescript": "^3.0.0",
+    "@graphql-codegen/visitor-plugin-common": "3.0.0",
+    "@urql/introspection": "^1.0.0",
+    "tslib": "~2.5.0"
+  },
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "devDependencies": {
+    "graphql": "16.6.0"
+  },
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/typings/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "default": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "typings": "dist/typings/index.d.ts",
+  "typescript": {
+    "definition": "dist/typings/index.d.ts"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  },
+  "type": "module"
+}

--- a/packages/plugins/typescript/nhost/src/config.ts
+++ b/packages/plugins/typescript/nhost/src/config.ts
@@ -1,0 +1,7 @@
+import { RawTypesConfig } from '@graphql-codegen/visitor-plugin-common';
+
+/**
+ * @description This plugin generates the Typescript schema that enables queries and mutations to be typed in the Nhost SDK.
+ *
+ */
+export interface NhostPluginConfig extends Pick<RawTypesConfig, 'scalars'> {}

--- a/packages/plugins/typescript/nhost/src/index.ts
+++ b/packages/plugins/typescript/nhost/src/index.ts
@@ -1,0 +1,48 @@
+import { getIntrospectedSchema, minifyIntrospectionQuery } from '@urql/introspection';
+
+import { plugin as typescriptPlugin, TypeScriptPluginConfig } from '@graphql-codegen/typescript';
+import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
+import { NhostPluginConfig } from './config';
+
+type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
+
+export const plugin: PluginFunction<NhostPluginConfig, Types.ComplexPluginOutput> = (schema, documents, config) => {
+  // * We don't allow the other @graphql-codegen/typescript options as they could break the generator and the types.
+  const { scalars } = config;
+  const conf: TypeScriptPluginConfig = {
+    scalars,
+    declarationKind: 'type',
+    enumsAsTypes: true,
+    // * Add underscore to args type to avoid conflicts with the generated types
+    // * See: https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#addunderscoretoargstype
+    addUnderscoreToArgsType: true,
+  };
+  const minifiedData = minifyIntrospectionQuery(getIntrospectedSchema(schema), {
+    includeDirectives: false,
+    includeEnums: true,
+    includeInputs: true,
+    includeScalars: true,
+  });
+
+  const { prepend, content } = typescriptPlugin(schema, documents, conf) as UnwrapPromise<
+    ReturnType<typeof typescriptPlugin>
+  >;
+
+  // * https://stackoverflow.com/questions/2008279/validate-a-javascript-function-name
+  const types = Array.from(content.matchAll(/^export type ([$A-Z_][0-9A-Z_$]*) = /gim))
+    .map(([, name]) => `\n${name}: ${name}`)
+    .join(',');
+
+  const result = `
+export default {
+  introspection: ${JSON.stringify(minifiedData, null, 2).replace(/^/gm, '  ').slice(2)} as const,
+  types: {} as {${types.replace(/^/gm, '    ').slice(4)}
+  }
+}`;
+
+  return {
+    prepend,
+    content: [content, result].join('\n'),
+  };
+};
+export default plugin;

--- a/packages/plugins/typescript/nhost/tests/__snapshots__/nhost.spec.ts.snap
+++ b/packages/plugins/typescript/nhost/tests/__snapshots__/nhost.spec.ts.snap
@@ -1,0 +1,734 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TypeScript Operations Plugin Nhost plugin should generate the nhost-compatibel schema 1`] = `
+Object {
+  "content": "/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  DateTime: any;
+};
+
+export type InputType = {
+  t?: InputMaybe<Scalars['String']>;
+};
+
+export type User = {
+  __typename?: 'User';
+  id: Scalars['ID'];
+  username: Scalars['String'];
+  email: Scalars['String'];
+  profile?: Maybe<Profile>;
+  role?: Maybe<Role>;
+};
+
+export type Profile = {
+  __typename?: 'Profile';
+  age?: Maybe<Scalars['Int']>;
+  firstName: Scalars['String'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  test?: Maybe<Scalars['String']>;
+  login?: Maybe<User>;
+};
+
+
+export type Mutation_LoginArgs = {
+  username: Scalars['String'];
+  password: Scalars['String'];
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  userCreated?: Maybe<User>;
+};
+
+export type Notifiction = {
+  id: Scalars['ID'];
+  createdAt: Scalars['String'];
+};
+
+export type TextNotification = Notifiction & {
+  __typename?: 'TextNotification';
+  id: Scalars['ID'];
+  text: Scalars['String'];
+  createdAt: Scalars['String'];
+};
+
+export type ImageNotification = Notifiction & {
+  __typename?: 'ImageNotification';
+  id: Scalars['ID'];
+  imageUrl: Scalars['String'];
+  metadata: ImageMetadata;
+  createdAt: Scalars['String'];
+};
+
+export type ImageMetadata = {
+  __typename?: 'ImageMetadata';
+  createdBy: Scalars['String'];
+};
+
+export type Role =
+  | 'USER'
+  | 'ADMIN';
+
+export type MyUnion = User | Profile;
+
+export type AnyNotification = TextNotification | ImageNotification;
+
+export type SearchResult = TextNotification | ImageNotification | User;
+
+export type Query = {
+  __typename?: 'Query';
+  me?: Maybe<User>;
+  unionTest?: Maybe<MyUnion>;
+  notifications: Array<Notifiction>;
+  mixedNotifications: Array<AnyNotification>;
+  search: Array<SearchResult>;
+  dummy?: Maybe<Scalars['String']>;
+  dummyNonNull: Scalars['String'];
+  dummyArray?: Maybe<Array<Maybe<Scalars['String']>>>;
+  dummyNonNullArray: Array<Maybe<Scalars['String']>>;
+  dummyNonNullArrayWithValues: Array<Scalars['String']>;
+  dummyWithType?: Maybe<Profile>;
+};
+
+
+export type Query_SearchArgs = {
+  term: Scalars['String'];
+};
+
+
+export default {
+  introspection: {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      },
+      "types": [
+        {
+          "kind": "SCALAR",
+          "name": "DateTime"
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "InputType",
+          "inputFields": [
+            {
+              "name": "t",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String"
+        },
+        {
+          "kind": "OBJECT",
+          "name": "User",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "username",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "email",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "profile",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Profile",
+                "ofType": null
+              },
+              "args": []
+            },
+            {
+              "name": "role",
+              "type": {
+                "kind": "ENUM",
+                "name": "Role",
+                "ofType": null
+              },
+              "args": []
+            }
+          ],
+          "interfaces": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID"
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Profile",
+          "fields": [
+            {
+              "name": "age",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "args": []
+            },
+            {
+              "name": "firstName",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            }
+          ],
+          "interfaces": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int"
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "fields": [
+            {
+              "name": "test",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "args": []
+            },
+            {
+              "name": "login",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "args": [
+                {
+                  "name": "username",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "name": "password",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "interfaces": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "fields": [
+            {
+              "name": "userCreated",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "args": []
+            }
+          ],
+          "interfaces": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Notifiction",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            }
+          ],
+          "interfaces": [],
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "TextNotification"
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ImageNotification"
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TextNotification",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "text",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            }
+          ],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Notifiction"
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ImageNotification",
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "imageUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ImageMetadata",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            }
+          ],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Notifiction"
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ImageMetadata",
+          "fields": [
+            {
+              "name": "createdBy",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            }
+          ],
+          "interfaces": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Role",
+          "enumValues": [
+            {
+              "name": "USER"
+            },
+            {
+              "name": "ADMIN"
+            }
+          ]
+        },
+        {
+          "kind": "UNION",
+          "name": "MyUnion",
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "User"
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Profile"
+            }
+          ]
+        },
+        {
+          "kind": "UNION",
+          "name": "AnyNotification",
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "TextNotification"
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ImageNotification"
+            }
+          ]
+        },
+        {
+          "kind": "UNION",
+          "name": "SearchResult",
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "TextNotification"
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ImageNotification"
+            },
+            {
+              "kind": "OBJECT",
+              "name": "User"
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "fields": [
+            {
+              "name": "me",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "args": []
+            },
+            {
+              "name": "unionTest",
+              "type": {
+                "kind": "UNION",
+                "name": "MyUnion",
+                "ofType": null
+              },
+              "args": []
+            },
+            {
+              "name": "notifications",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "INTERFACE",
+                      "name": "Notifiction",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "mixedNotifications",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "AnyNotification",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "search",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "SearchResult",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "args": [
+                {
+                  "name": "term",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "name": "dummy",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "args": []
+            },
+            {
+              "name": "dummyNonNull",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "dummyArray",
+              "type": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "dummyNonNullArray",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "dummyNonNullArrayWithValues",
+              "type": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "LIST",
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "args": []
+            },
+            {
+              "name": "dummyWithType",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Profile",
+                "ofType": null
+              },
+              "args": []
+            }
+          ],
+          "interfaces": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean"
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Any"
+        }
+      ],
+      "directives": []
+    }
+  } as const,
+  types: {} as {
+    Scalars: Scalars,
+    InputType: InputType,
+    User: User,
+    Profile: Profile,
+    Mutation: Mutation,
+    Mutation_LoginArgs: Mutation_LoginArgs,
+    Subscription: Subscription,
+    Notifiction: Notifiction,
+    TextNotification: TextNotification,
+    ImageNotification: ImageNotification,
+    ImageMetadata: ImageMetadata,
+    MyUnion: MyUnion,
+    AnyNotification: AnyNotification,
+    SearchResult: SearchResult,
+    Query: Query,
+    Query_SearchArgs: Query_SearchArgs
+  }
+}",
+  "prepend": Array [
+    "export type Maybe<T> = T | null;",
+    "export type InputMaybe<T> = Maybe<T>;",
+    "export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };",
+    "export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };",
+    "export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };",
+  ],
+}
+`;

--- a/packages/plugins/typescript/nhost/tests/__snapshots__/nhost.spec.ts.snap
+++ b/packages/plugins/typescript/nhost/tests/__snapshots__/nhost.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TypeScript Operations Plugin Nhost plugin should generate the nhost-compatibel schema 1`] = `
+exports[`TypeScript Nhost Plugin should generate the nhost-compatible schema 1`] = `
 Object {
   "content": "/** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/packages/plugins/typescript/nhost/tests/nhost.spec.ts
+++ b/packages/plugins/typescript/nhost/tests/nhost.spec.ts
@@ -1,7 +1,7 @@
 import { buildSchema } from 'graphql';
 import { plugin } from '../src/index.js';
 
-describe('TypeScript Operations Plugin', () => {
+describe('TypeScript Nhost Plugin', () => {
   const schema = buildSchema(/* GraphQL */ `
     scalar DateTime
 

--- a/packages/plugins/typescript/nhost/tests/nhost.spec.ts
+++ b/packages/plugins/typescript/nhost/tests/nhost.spec.ts
@@ -85,7 +85,7 @@ describe('TypeScript Operations Plugin', () => {
   `);
 
   describe('Nhost plugin', () => {
-    it('should generate the nhost-compatibel schema', async () => {
+    it('should generate the nhost-compatible schema', async () => {
       const result = await plugin(schema, [], {}, { outputFile: '' });
       expect(result).toMatchSnapshot();
     });

--- a/packages/plugins/typescript/nhost/tests/nhost.spec.ts
+++ b/packages/plugins/typescript/nhost/tests/nhost.spec.ts
@@ -84,10 +84,8 @@ describe('TypeScript Nhost Plugin', () => {
     }
   `);
 
-  describe('Nhost plugin', () => {
-    it('should generate the nhost-compatible schema', async () => {
-      const result = await plugin(schema, [], {}, { outputFile: '' });
-      expect(result).toMatchSnapshot();
-    });
+  it('should generate the nhost-compatible schema', async () => {
+    const result = await plugin(schema, [], {}, { outputFile: '' });
+    expect(result).toMatchSnapshot();
   });
 });

--- a/packages/plugins/typescript/nhost/tests/nhost.spec.ts
+++ b/packages/plugins/typescript/nhost/tests/nhost.spec.ts
@@ -1,0 +1,93 @@
+import { buildSchema } from 'graphql';
+import { plugin } from '../src/index.js';
+
+describe('TypeScript Operations Plugin', () => {
+  const schema = buildSchema(/* GraphQL */ `
+    scalar DateTime
+
+    input InputType {
+      t: String
+    }
+
+    type User {
+      id: ID!
+      username: String!
+      email: String!
+      profile: Profile
+      role: Role
+    }
+
+    type Profile {
+      age: Int
+      firstName: String!
+    }
+
+    type Mutation {
+      test: String
+      login(username: String!, password: String!): User
+    }
+
+    type Subscription {
+      userCreated: User
+    }
+
+    interface Notifiction {
+      id: ID!
+      createdAt: String!
+    }
+
+    type TextNotification implements Notifiction {
+      id: ID!
+      text: String!
+      createdAt: String!
+    }
+
+    type ImageNotification implements Notifiction {
+      id: ID!
+      imageUrl: String!
+      metadata: ImageMetadata!
+      createdAt: String!
+    }
+
+    type ImageMetadata {
+      createdBy: String!
+    }
+
+    enum Role {
+      USER
+      ADMIN
+    }
+
+    union MyUnion = User | Profile
+
+    union AnyNotification = TextNotification | ImageNotification
+    union SearchResult = TextNotification | ImageNotification | User
+
+    type Query {
+      me: User
+      unionTest: MyUnion
+      notifications: [Notifiction!]!
+      mixedNotifications: [AnyNotification!]!
+      search(term: String!): [SearchResult!]!
+      dummy: String
+      dummyNonNull: String!
+      dummyArray: [String]
+      dummyNonNullArray: [String]!
+      dummyNonNullArrayWithValues: [String!]!
+      dummyWithType: Profile
+    }
+
+    schema {
+      query: Query
+      mutation: Mutation
+      subscription: Subscription
+    }
+  `);
+
+  describe('Nhost plugin', () => {
+    it('should generate the nhost-compatibel schema', async () => {
+      const result = await plugin(schema, [], {}, { outputFile: '' });
+      expect(result).toMatchSnapshot();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,6 +1440,18 @@
     lodash "~4.17.0"
     tslib "~2.4.0"
 
+"@graphql-codegen/plugin-helpers@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-4.0.0.tgz#9c10e4700dc6efe657781dff47347d0c99674061"
+  integrity sha512-vgNGTanT36hC4RAC/LAThMEjDvnu3WCyx6MtKZcPUtfCWFxbUAr88+OarGl1LAEiOef0agIREC7tIBXCqjKkJA==
+  dependencies:
+    "@graphql-tools/utils" "^9.0.0"
+    change-case-all "1.0.15"
+    common-tags "1.8.2"
+    import-from "4.0.0"
+    lodash "~4.17.0"
+    tslib "~2.4.0"
+
 "@graphql-codegen/schema-ast@^2.5.0", "@graphql-codegen/schema-ast@^2.5.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-2.5.1.tgz#ce030ae6de5dacd745848009ba0ca18c9c30910c"
@@ -1447,6 +1459,15 @@
   dependencies:
     "@graphql-codegen/plugin-helpers" "^2.6.2"
     "@graphql-tools/utils" "^8.8.0"
+    tslib "~2.4.0"
+
+"@graphql-codegen/schema-ast@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-3.0.0.tgz#3311a58184f885853d33d8272c527ff5bdf3023b"
+  integrity sha512-5gC8nNk/bxufS2LBSpaPExRgn6eNo8LQdtwDtwfM9XGEzt/F6rIBQoyOmqqwkiBmgu1PHHH8kLZMBYvYB1x5DA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^4.0.0"
+    "@graphql-tools/utils" "^9.0.0"
     tslib "~2.4.0"
 
 "@graphql-codegen/testing@1.18.0":
@@ -1483,6 +1504,17 @@
     auto-bind "~4.0.0"
     tslib "~2.4.0"
 
+"@graphql-codegen/typescript@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-3.0.0.tgz#473dde1646540039bca5db4b6daf174d13af0ce3"
+  integrity sha512-FQWyuIUy1y+fxb9+EZfvdBHBQpYExlIBHV5sg2WGNCsyVyCqBTl0mO8icyOtsQPVg6YFMFe8JJO69vQbwHma5w==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^4.0.0"
+    "@graphql-codegen/schema-ast" "^3.0.0"
+    "@graphql-codegen/visitor-plugin-common" "3.0.0"
+    auto-bind "~4.0.0"
+    tslib "~2.4.0"
+
 "@graphql-codegen/visitor-plugin-common@2.13.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz#2228660f6692bcdb96b1f6d91a0661624266b76b"
@@ -1505,6 +1537,22 @@
   integrity sha512-xE6iLDhr9sFM1qwCGJcCXRu5MyA0moapG2HVejwyAXXLubYKYwWnoiEigLH2b5iauh6xsl6XP8hh9D1T1dn5Cw==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^3.1.2"
+    "@graphql-tools/optimize" "^1.3.0"
+    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
+    "@graphql-tools/utils" "^9.0.0"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.15"
+    dependency-graph "^0.11.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "~2.4.0"
+
+"@graphql-codegen/visitor-plugin-common@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-3.0.0.tgz#527185eb3b1b06739702084bc6263713e167a166"
+  integrity sha512-ZoNlCmmkGClB137SpJT9og/nkihLN7Z4Ynl9Ir3OlbDuI20dbpyXsclpr9QGLcxEcfQeVfhGw9CooW7wZJJ8LA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^4.0.0"
     "@graphql-tools/optimize" "^1.3.0"
     "@graphql-tools/relay-operation-optimizer" "^6.5.0"
     "@graphql-tools/utils" "^9.0.0"
@@ -2583,7 +2631,7 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
-"@types/json-schema@7.0.9", "@types/json-schema@^7.0.9":
+"@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -2863,6 +2911,11 @@
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@urql/introspection/-/introspection-0.3.2.tgz#18b737e17779cecb74e612a965ed5dc17b978355"
   integrity sha512-dbszrDgTyTM1ndvdTe4X7RUciVi2zXxjHhTIrWOSvU3FODX4+90uSVtdn5bXwTuwqM4bxVEc1ekaLYEUeiNLsg==
+
+"@urql/introspection@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@urql/introspection/-/introspection-1.0.0.tgz#e63b22eb66261320c2427c8de604ec24453e85b7"
+  integrity sha512-LV4MNqslkGqdlmAjpmVuyewQ6sQZ1CAaHXsiP7IaNKWKKlnpluxjiQnhLy3V1uhqIcJe/Ni/+sHIq78EvpkJNw==
 
 "@vercel/ncc@^0.34.0":
   version "0.34.0"
@@ -5332,7 +5385,7 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
-graphql-config@4.3.6, graphql-config@^4.1.0:
+graphql-config@4.3.6:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.3.6.tgz#908ef03d6670c3068e51fe2e84e10e3e0af220b6"
   integrity sha512-i7mAPwc0LAZPnYu2bI8B6yXU5820Wy/ArvmOseDLZIu0OU1UTULEuexHo6ZcHXeT9NvGGaUPQZm8NV3z79YydA==
@@ -5369,41 +5422,6 @@ graphql-jit@0.7.4:
     lodash.merge "4.6.2"
     lodash.mergewith "4.6.2"
 
-graphql-language-service-interface@2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-interface/-/graphql-language-service-interface-2.10.2.tgz#de9386f699e446320256175e215cdc10ccf9f9b7"
-  integrity sha512-RKIEBPhRMWdXY3fxRs99XysTDnEgAvNbu8ov/5iOlnkZsWQNzitjtd0O0l1CutQOQt3iXoHde7w8uhCnKL4tcg==
-  dependencies:
-    graphql-config "^4.1.0"
-    graphql-language-service-parser "^1.10.4"
-    graphql-language-service-types "^1.8.7"
-    graphql-language-service-utils "^2.7.1"
-    vscode-languageserver-types "^3.15.1"
-
-graphql-language-service-parser@^1.10.4:
-  version "1.10.4"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-parser/-/graphql-language-service-parser-1.10.4.tgz#b2979deefc5c0df571dacd409b2d5fbf1cdf7a9d"
-  integrity sha512-duDE+0aeKLFVrb9Kf28U84ZEHhHcvTjWIT6dJbIAQJWBaDoht0D4BK9EIhd94I3DtKRc1JCJb2+70y1lvP/hiA==
-  dependencies:
-    graphql-language-service-types "^1.8.7"
-
-graphql-language-service-types@^1.8.7:
-  version "1.8.7"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-types/-/graphql-language-service-types-1.8.7.tgz#f5e909e6d9334ea2d8d1f7281b695b6f5602c07f"
-  integrity sha512-LP/Mx0nFBshYEyD0Ny6EVGfacJAGVx+qXtlJP4hLzUdBNOGimfDNtMVIdZANBXHXcM41MDgMHTnyEx2g6/Ttbw==
-  dependencies:
-    graphql-config "^4.1.0"
-    vscode-languageserver-types "^3.15.1"
-
-graphql-language-service-utils@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-utils/-/graphql-language-service-utils-2.7.1.tgz#c97c8d744a761480aba7e03e4a42adf28b6fce39"
-  integrity sha512-Wci5MbrQj+6d7rfvbORrA9uDlfMysBWYaG49ST5TKylNaXYFf3ixFOa74iM1KtM9eidosUbI3E1JlWi0JaidJA==
-  dependencies:
-    "@types/json-schema" "7.0.9"
-    graphql-language-service-types "^1.8.7"
-    nullthrows "^1.0.0"
-
 graphql-request@5.0.0, graphql-request@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-5.0.0.tgz#7504a807d0e11be11a3c448e900f0cc316aa18ef"
@@ -5435,7 +5453,7 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.9.1.tgz#9c0fa48ceb695d61d574ed3ab21b426729e87f2d"
   integrity sha512-mL/SWGBwIT9Meq0NlfS55yXXTOeWPMbK7bZBEZhFu46bcGk1coTx2Sdtzxdk+9yHWngD+Fk1PZDWaAutQa9tpw==
 
-graphql@16.6.0, graphql@^16.0.0:
+graphql@16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
@@ -6213,7 +6231,7 @@ jest-resolve@^28.1.3:
     resolve.exports "^1.1.0"
     slash "^3.0.0"
 
-jest-runner@28.1.3, jest-runner@^28.1.3:
+jest-runner@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-28.1.3.tgz#5eee25febd730b4713a2cdfd76bdd5557840f9a1"
   integrity sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==
@@ -7111,7 +7129,7 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-nullthrows@^1.0.0, nullthrows@^1.1.1:
+nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
@@ -8656,7 +8674,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.4.1, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@~2.4.0:
+tslib@2.4.1, tslib@~2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
@@ -8666,7 +8684,7 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.5.0:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0, tslib@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
@@ -8936,11 +8954,6 @@ vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
-
-vscode-languageserver-types@^3.15.1:
-  version "3.17.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
-  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
 
 vue-apollo-smart-ops@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Description

Typescript plugin for the [Nhost GraphQL client to come](https://github.com/nhost/nhost/pull/1587).
As some team members from The Guild already know, Nhost is about to release a client that generates GraphQL operations from a serializable object. Both this object and the GraphQL result are strongly typed from the schema generated by this plugin.

What the plugin does:
- Generate types with `graphql-codegem/typescript`, following a strict configuration. (the plugin does not require `@graphql-codegen/typescript` to be installed by the user but is use as a dependency).
- Minify the introspection object with `'@urql/introspection`
- Export the introspection object as well as all the types so they can be accessed through a default `import schema from './generated-schema'`

[Related documentation PR](https://github.com/dotansimha/graphql-code-generator/pull/8975)

## Type of change

- [x] New plugin

## Sandbox:

[Preview of how the client will work](https://stackblitz.com/edit/nhost-graphql-client?file=play%2Findex.test.ts)

## How Has This Been Tested?

Follows the Guild guidelines

**Test Environment**:

- OS: Mac OSX
- NodeJS: 16

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
