### PR TITLE
fix(typescript-apollo-angular): update to generic type constaint of @apollo/client@3.7

### DIFF
--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -408,7 +408,7 @@ ${camelCase(o.node.name.value)}Watch(variables${
         ? `type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;`
         : '';
     const watchType = hasQueries
-      ? `interface WatchQueryOptionsAlone<V> extends Omit<ApolloCore.WatchQueryOptions<V>, 'query' | 'variables'> {}`
+      ? `interface WatchQueryOptionsAlone<V extends ApolloCore.OperationVariables> extends Omit<ApolloCore.WatchQueryOptions<V>, 'query' | 'variables'> {}`
       : '';
     const queryType = hasQueries
       ? `interface QueryOptionsAlone<V> extends Omit<ApolloCore.QueryOptions<V>, 'query' | 'variables'> {}`


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

@apollo/client@3.7 updated their TS supprort in the following commit:
 https://github.com/apollographql/apollo-client/commit/47435e879ebc867d9fc3de5b6fd5785204b4dbd4#diff-3d26f2a8fa68cc60ff4736cbafa9986e14eed51e341fc224ca4ac01ee8d671a6 

The change now required that the generic argument of WatchQueryOptions must now extend OperationVariables. 
I added that requirment to the generated files.


Related # (issue)

https://github.com/dotansimha/graphql-code-generator-community/issues/305

## Type of change
Minor code change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran the codegen and it now generated a working TS file

**Test Environment**:

- OS: MacOs
- `@graphql-codegen/...`: 3.0.2
- NodeJS: 16

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

