### PR TITLE
Drop Node 12 support

### DIFF
--- a/.changeset/twelve-peas-approve.md
+++ b/.changeset/twelve-peas-approve.md
@@ -1,0 +1,50 @@
+---
+'@graphql-codegen/c-sharp': major
+'@graphql-codegen/c-sharp-common': major
+'@graphql-codegen/c-sharp-operations': major
+'@graphql-codegen/flutter-freezed': major
+'@graphql-codegen/flow': major
+'@graphql-codegen/flow-operations': major
+'@graphql-codegen/flow-resolvers': major
+'@graphql-codegen/java-apollo-android': major
+'@graphql-codegen/java-common': major
+'@graphql-codegen/java': major
+'@graphql-codegen/kotlin': major
+'@graphql-codegen/java-resolvers': major
+'@graphql-codegen/hasura-allow-list': major
+'@graphql-codegen/jsdoc': major
+'@graphql-codegen/urql-introspection': major
+'@graphql-codegen/typescript-apollo-angular': major
+'@graphql-codegen/typescript-apollo-client-helpers': major
+'@graphql-codegen/typescript-enum-array': major
+'@graphql-codegen/typescript-generic-sdk': major
+'@graphql-codegen/typescript-graphql-apollo': major
+'@graphql-codegen/typescript-graphql-files-modules': major
+'@graphql-codegen/typescript-graphql-request': major
+'@graphql-codegen/typescript-jit-sdk': major
+'@graphql-codegen/typescript-mongodb': major
+'@graphql-codegen/typescript-msw': major
+'@graphql-codegen/named-operations-object': major
+'@graphql-codegen/typescript-nhost': major
+'@graphql-codegen/typescript-oclif': major
+'@graphql-codegen/typescript-react-apollo': major
+'@graphql-codegen/typescript-react-offix': major
+'@graphql-codegen/typescript-react-query': major
+'@graphql-codegen/typescript-rtk-query': major
+'@graphql-codegen/typescript-stencil-apollo': major
+'@graphql-codegen/typescript-type-graphql': major
+'@graphql-codegen/typescript-urql': major
+'@graphql-codegen/typescript-urql-graphcache': major
+'@graphql-codegen/urql-svelte-operations-store': major
+'@graphql-codegen/typescript-vue-apollo': major
+'@graphql-codegen/typescript-vue-apollo-smart-ops': major
+'@graphql-codegen/typescript-vue-urql': major
+'@graphql-codegen/import-types-preset': major
+'@graphql-codegen/near-operation-file-preset': major
+---
+
+Drops Node 12 support.
+
+Node 12 stopped receiving active support from October 2020, and security support from April 2022. If you are using Node 12, you should update to a supported runtime.
+
+This changeset does not include code changes, so plugins may still work with Node 12. However, we have stopped running unit tests in CI on Node 12.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,10 +83,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # remove windows to speed up the tests
-        node_version: [12, 14, 16, 18]
+        node_version: [14, 16, 18]
         graphql_version: [15, 16]
         include:
-          - node-version: 12
+          - node-version: 18
             os: windows-latest
             graphql_version: 16
     steps:


### PR DESCRIPTION
## Description

CI is broken on Node 12, which is a end of life version of Node. graphql-code-generator already dropped support for Node 12.

Related #312

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules