### PR TITLE
feat(react-query): exposeQueryRootKeys

### DIFF
--- a/.changeset/famous-islands-joke.md
+++ b/.changeset/famous-islands-joke.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-react-query": minor
+---
+
+add exposeQueryRootKeys

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -64,6 +64,18 @@ export interface ReactQueryRawPluginConfig
 
   /**
    * @default false
+   * @description For each generate query hook adds rootKey. Useful for cache updates.
+   * @exampleMarkdown
+   * ```ts
+   * const query = useUserDetailsQuery(...)
+   * const key = useUserDetailsQuery.rootKey
+   * // use key in a cache update after a mutation
+   * ```
+   */
+  exposeQueryRootKeys?: boolean;
+
+  /**
+   * @default false
    * @description For each generate mutation hook adds getKey() function. Useful for call outside of functional component.
    * @exampleMarkdown
    * ```ts

--- a/packages/plugins/typescript/react-query/src/variables-generator.ts
+++ b/packages/plugins/typescript/react-query/src/variables-generator.ts
@@ -27,6 +27,13 @@ export function generateInfiniteQueryKeyMaker(
   )};\n`;
 }
 
+export function generateInfiniteQueryRootKeyMaker(
+  node: OperationDefinitionNode,
+  operationName: string,
+) {
+  return `\nuseInfinite${operationName}.rootKey = '${node.name.value}.infinite';\n`;
+}
+
 export function generateQueryKey(
   node: OperationDefinitionNode,
   hasRequiredVariables: boolean,
@@ -46,6 +53,13 @@ export function generateQueryKeyMaker(
     node,
     hasRequiredVariables,
   )};\n`;
+}
+
+export function generateQueryRootKeyMaker(
+  node: OperationDefinitionNode,
+  operationName: string,
+) {
+  return `\nuse${operationName}.rootKey = '${node.name.value}';\n`;
 }
 
 export function generateMutationKey(node: OperationDefinitionNode): string {

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -17,14 +17,17 @@ import { GraphQLRequestClientFetcher } from './fetcher-graphql-request.js';
 import { FetcherRenderer } from './fetcher.js';
 import {
   generateInfiniteQueryKeyMaker,
+  generateInfiniteQueryRootKeyMaker,
   generateMutationKeyMaker,
   generateQueryKeyMaker,
+  generateQueryRootKeyMaker,
 } from './variables-generator.js';
 
 export interface ReactQueryPluginConfig extends ClientSideBasePluginConfig {
   errorType: string;
   exposeDocument: boolean;
   exposeQueryKeys: boolean;
+  exposeQueryRootKeys: boolean;
   exposeMutationKeys: boolean;
   exposeFetcher: boolean;
   addInfiniteQuery: boolean;
@@ -81,6 +84,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
       errorType: getConfigValue(rawConfig.errorType, 'unknown'),
       exposeDocument: getConfigValue(rawConfig.exposeDocument, false),
       exposeQueryKeys: getConfigValue(rawConfig.exposeQueryKeys, false),
+      exposeQueryRootKeys: getConfigValue(rawConfig.exposeQueryRootKeys, false),
       exposeMutationKeys: getConfigValue(rawConfig.exposeMutationKeys, false),
       exposeFetcher: getConfigValue(rawConfig.exposeFetcher, false),
       addInfiniteQuery: getConfigValue(rawConfig.addInfiniteQuery, false),
@@ -192,6 +196,12 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
           hasRequiredVariables,
         )};\n`;
       }
+      if (this.config.exposeQueryRootKeys) {
+        query += `\n${generateQueryRootKeyMaker(
+          node,
+          operationName,
+        )}`
+      }
       if (this.config.addInfiniteQuery) {
         query += `\n${this.fetcher.generateInfiniteQueryHook(
           node,
@@ -208,6 +218,12 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
             operationVariablesTypes,
             hasRequiredVariables,
           )};\n`;
+        }
+        if (this.config.exposeQueryRootKeys) {
+          query += `\n${generateInfiniteQueryRootKeyMaker(
+            node,
+            operationName,
+          )}`
         }
       }
 

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -183,7 +183,7 @@ export const useTestMutation = <
     );"
 `;
 
-exports[`React-Query exposeQueryRootKeys: true, addInfiniteQuery: true Should generate getKey for each query - also infinite queries 1`] = `
+exports[`React-Query exposeQueryRootKeys: true, addInfiniteQuery: true Should generate rootKey for each query - also infinite queries 1`] = `
 "
 export const TestDocument = \`
     query test {

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -1,5 +1,260 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`React-Query exposeQueryKeys: true Should generate getKey for each query 1`] = `
+"
+export const TestDocument = \`
+    query test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const useTestQuery = <
+      TData = TestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      variables?: TestQueryVariables,
+      options?: UseQueryOptions<TestQuery, TError, TData>
+    ) =>
+    useQuery<TestQuery, TError, TData>(
+      variables === undefined ? ['test'] : ['test', variables],
+      fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+      options
+    );
+
+useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];
+;
+
+export const TestDocument = \`
+    mutation test($name: String) {
+  submitRepository(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      options?: UseMutationOptions<TestMutation, TError, TestMutationVariables, TContext>
+    ) =>
+    useMutation<TestMutation, TError, TestMutationVariables, TContext>(
+      ['test'],
+      (variables?: TestMutationVariables) => fetcher<TestMutation, TestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
+      options
+    );"
+`;
+
+exports[`React-Query exposeQueryKeys: true, addInfiniteQuery: true Should generate getKey for each query - also infinite queries 1`] = `
+"
+export const TestDocument = \`
+    query test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const useTestQuery = <
+      TData = TestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      variables?: TestQueryVariables,
+      options?: UseQueryOptions<TestQuery, TError, TData>
+    ) =>
+    useQuery<TestQuery, TError, TData>(
+      variables === undefined ? ['test'] : ['test', variables],
+      fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+      options
+    );
+
+useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];
+;
+
+export const useInfiniteTestQuery = <
+      TData = TestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      pageParamKey: keyof TestQueryVariables,
+      variables?: TestQueryVariables,
+      options?: UseInfiniteQueryOptions<TestQuery, TError, TData>
+    ) =>
+    useInfiniteQuery<TestQuery, TError, TData>(
+      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
+      options
+    );
+
+
+useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite'] : ['test.infinite', variables];
+;
+
+export const TestDocument = \`
+    mutation test($name: String) {
+  submitRepository(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      options?: UseMutationOptions<TestMutation, TError, TestMutationVariables, TContext>
+    ) =>
+    useMutation<TestMutation, TError, TestMutationVariables, TContext>(
+      ['test'],
+      (variables?: TestMutationVariables) => fetcher<TestMutation, TestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
+      options
+    );"
+`;
+
+exports[`React-Query exposeQueryRootKeys: true Should generate rootKey for each query 1`] = `
+"
+export const TestDocument = \`
+    query test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const useTestQuery = <
+      TData = TestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      variables?: TestQueryVariables,
+      options?: UseQueryOptions<TestQuery, TError, TData>
+    ) =>
+    useQuery<TestQuery, TError, TData>(
+      variables === undefined ? ['test'] : ['test', variables],
+      fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+      options
+    );
+
+useTestQuery.rootKey = 'test';
+
+export const TestDocument = \`
+    mutation test($name: String) {
+  submitRepository(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      options?: UseMutationOptions<TestMutation, TError, TestMutationVariables, TContext>
+    ) =>
+    useMutation<TestMutation, TError, TestMutationVariables, TContext>(
+      ['test'],
+      (variables?: TestMutationVariables) => fetcher<TestMutation, TestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
+      options
+    );"
+`;
+
+exports[`React-Query exposeQueryRootKeys: true, addInfiniteQuery: true Should generate getKey for each query - also infinite queries 1`] = `
+"
+export const TestDocument = \`
+    query test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const useTestQuery = <
+      TData = TestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      variables?: TestQueryVariables,
+      options?: UseQueryOptions<TestQuery, TError, TData>
+    ) =>
+    useQuery<TestQuery, TError, TData>(
+      variables === undefined ? ['test'] : ['test', variables],
+      fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+      options
+    );
+
+useTestQuery.rootKey = 'test';
+
+export const useInfiniteTestQuery = <
+      TData = TestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      pageParamKey: keyof TestQueryVariables,
+      variables?: TestQueryVariables,
+      options?: UseInfiniteQueryOptions<TestQuery, TError, TData>
+    ) =>
+    useInfiniteQuery<TestQuery, TError, TData>(
+      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
+      options
+    );
+
+
+useInfiniteTestQuery.rootKey = 'test.infinite';
+
+export const TestDocument = \`
+    mutation test($name: String) {
+  submitRepository(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      options?: UseMutationOptions<TestMutation, TError, TestMutationVariables, TContext>
+    ) =>
+    useMutation<TestMutation, TError, TestMutationVariables, TContext>(
+      ['test'],
+      (variables?: TestMutationVariables) => fetcher<TestMutation, TestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
+      options
+    );"
+`;
+
 exports[`React-Query fetcher: custom-mapper Should generate mutation correctly with lazy variables 1`] = `
 "
 export const TestDocument = \`

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -1307,9 +1307,7 @@ export const useTestMutation = <
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toMatchSnapshot();
-      expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.rootKey = 'test';`,
-      );
+      expect(out.content).toBeSimilarStringTo(`useTestQuery.rootKey = 'test';`);
     });
   });
 
@@ -1322,9 +1320,8 @@ export const useTestMutation = <
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toMatchSnapshot();
-      expect(out.content).toBeSimilarStringTo(
-        `useInfiniteTestQuery.rootKey = 'test.infinite';`,
-      );
+      expect(out.content).toBeSimilarStringTo(`useTestQuery.rootKey = 'test';`);
+      expect(out.content).toBeSimilarStringTo(`useInfiniteTestQuery.rootKey = 'test.infinite';`);
     });
   });
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -1274,6 +1274,7 @@ export const useTestMutation = <
         exposeQueryKeys: true,
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toMatchSnapshot();
       expect(out.content).toBeSimilarStringTo(
         `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];`,
       );
@@ -1288,11 +1289,41 @@ export const useTestMutation = <
         addInfiniteQuery: true,
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toMatchSnapshot();
       expect(out.content).toBeSimilarStringTo(
         `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];`,
       );
       expect(out.content).toBeSimilarStringTo(
         `useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite'] : ['test.infinite', variables];`,
+      );
+    });
+  });
+
+  describe('exposeQueryRootKeys: true', () => {
+    it('Should generate rootKey for each query', async () => {
+      const config = {
+        fetcher: 'fetch',
+        exposeQueryRootKeys: true,
+      };
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toMatchSnapshot();
+      expect(out.content).toBeSimilarStringTo(
+        `useTestQuery.rootKey = 'test';`,
+      );
+    });
+  });
+
+  describe('exposeQueryRootKeys: true, addInfiniteQuery: true', () => {
+    it('Should generate getKey for each query - also infinite queries', async () => {
+      const config = {
+        fetcher: 'fetch',
+        exposeQueryRootKeys: true,
+        addInfiniteQuery: true,
+      };
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.content).toMatchSnapshot();
+      expect(out.content).toBeSimilarStringTo(
+        `useInfiniteTestQuery.rootKey = 'test.infinite';`,
       );
     });
   });

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -1312,7 +1312,7 @@ export const useTestMutation = <
   });
 
   describe('exposeQueryRootKeys: true, addInfiniteQuery: true', () => {
-    it('Should generate getKey for each query - also infinite queries', async () => {
+    it('Should generate rootKey for each query - also infinite queries', async () => {
       const config = {
         fetcher: 'fetch',
         exposeQueryRootKeys: true,


### PR DESCRIPTION
## Description

Need to get the cache key when the `variables` is required, `getKey` function is not able to do so

Related #18 

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] npm run test

**Test Environment**:

- OS: Mac OS 13.3
- NodeJS: 18.15.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
