### PR TITLE
Urql 4 now have more strict types for variables

### DIFF
--- a/.changeset/kind-pens-argue.md
+++ b/.changeset/kind-pens-argue.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-vue-urql': minor
+---
+
+Generate explicit type for variables used in a query to work with urql v4

--- a/packages/plugins/typescript/vue-urql/src/visitor.ts
+++ b/packages/plugins/typescript/vue-urql/src/visitor.ts
@@ -98,8 +98,8 @@ export function use${operationName}<R = ${operationResultType}>(options: Omit<Ur
     }
 
     return `
-export function use${operationName}(options: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes}>, 'query'> = {}) {
-  return Urql.use${operationType}<${operationResultType}>({ query: ${documentVariableName}, ...options });
+export function use${operationName}(options: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes}>, 'query'>) {
+  return Urql.use${operationType}<${operationResultType}, ${operationVariablesTypes}>({ query: ${documentVariableName}, ...options });
 };`;
   }
 

--- a/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
@@ -24,7 +24,7 @@ import * as Urql from '@urql/vue';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 
-export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, Operations.TestQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<Operations.TestQuery>({ query: Operations.TestDocument, ...options });
+export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, Operations.TestQueryVariables>, 'query'>) {
+  return Urql.useQuery<Operations.TestQuery, Operations.TestQueryVariables>({ query: Operations.TestDocument, ...options });
 };"
 `;

--- a/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
@@ -477,8 +477,8 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, FeedQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<FeedQuery>({ query: FeedDocument, ...options });
+export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, FeedQueryVariables>, 'query'>) {
+  return Urql.useQuery<FeedQuery, FeedQueryVariables>({ query: FeedDocument, ...options });
 };`);
 
       expect(content.content).toBeSimilarStringTo(`


### PR DESCRIPTION
## Description

Specify operation variable types explicitly in useQuery generated functions to be able to work with Urql 4.

Related #328
<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Environment**:

- OS: Linux
- `@graphql-codegen/typescript-vue-urql`:
- NodeJS: 18.14.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
