### PR TITLE
feature: support graphql-request 6+

### DIFF
--- a/.changeset/tough-olives-nail.md
+++ b/.changeset/tough-olives-nail.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-graphql-request": major
+---
+
+feature: support graphql-request 6+

--- a/packages/plugins/typescript/graphql-request/package.json
+++ b/packages/plugins/typescript/graphql-request/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-request": "^3.4.0 || ^4.0.0 || ~5.0.0 || ~5.1.0",
+    "graphql-request": "^6.0.0",
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@graphql-codegen/testing": "1.18.0",
     "@graphql-tools/schema": "9.0.16",
-    "graphql-request": "5.0.0"
+    "graphql-request": "6.0.0"
   },
   "publishConfig": {
     "directory": "dist",

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -46,10 +46,11 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
 
     const typeImport = this.config.useTypeImports ? 'import type' : 'import';
     const fileExtension = this.config.emitLegacyCommonJSImports ? '' : '.js';
+    const buildPath = this.config.emitLegacyCommonJSImports ? 'cjs' : 'esm';
 
     this._additionalImports.push(`${typeImport} { GraphQLClient } from 'graphql-request';`);
     this._additionalImports.push(
-      `${typeImport} * as Dom from 'graphql-request/dist/types.dom${fileExtension}';`,
+      `${typeImport} { GraphQLClientRequestHeaders } from 'graphql-request/build/${buildPath}/types${fileExtension}';`,
     );
 
     if (this.config.rawRequest && this.config.documentMode !== DocumentMode.string) {
@@ -126,7 +127,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
           }
           return `${operationName}(variables${optionalVariables ? '?' : ''}: ${
             o.operationVariablesTypes
-          }, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: ${
+          }, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: ${
             o.operationResultType
           }; extensions?: ${this.config.extensionsType}; headers: Dom.Headers; status: number; }> {
     return withWrapper((wrappedRequestHeaders) => client.rawRequest<${
@@ -136,7 +137,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
         }
         return `${operationName}(variables${optionalVariables ? '?' : ''}: ${
           o.operationVariablesTypes
-        }, requestHeaders?: Dom.RequestInit["headers"]): Promise<${o.operationResultType}> {
+        }, requestHeaders?: GraphQLClientRequestHeaders): Promise<${o.operationResultType}> {
   return withWrapper((wrappedRequestHeaders) => client.request<${
     o.operationResultType
   }>(${docVarName}, variables, {...requestHeaders, ...wrappedRequestHeaders}), '${operationName}', '${operationType}');

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -7,7 +7,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -245,16 +245,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FeedQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed2Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed3Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed4Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };
@@ -292,7 +292,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -531,16 +531,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FeedQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed2Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed3Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed4Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };
@@ -571,7 +571,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -809,16 +809,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FeedQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed2Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed3Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed4Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };
@@ -849,7 +849,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import type { GraphQLClient } from 'graphql-request';
-import type * as Dom from 'graphql-request/dist/types.dom';
+import type { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import { print } from 'graphql'
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
@@ -1092,16 +1092,16 @@ const Feed3DocumentString = print(Feed3Document);
 const Feed4DocumentString = print(Feed4Document);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: FeedQuery; extensions?: any; headers: Dom.Headers; status: number; }> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: FeedQuery; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<FeedQuery>(FeedDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed2Query; extensions?: any; headers: Dom.Headers; status: number; }> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed2Query; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed2Query>(Feed2DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed3Query; extensions?: any; headers: Dom.Headers; status: number; }> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed3Query; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed3Query>(Feed3DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed4Query; extensions?: any; headers: Dom.Headers; status: number; }> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed4Query; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed4Query>(Feed4DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };
@@ -1133,7 +1133,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom.js';
+import { GraphQLClientRequestHeaders } from 'graphql-request/build/esm/types.js';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -1372,16 +1372,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FeedQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed2Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed3Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed4Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };
@@ -1413,7 +1413,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import { print } from 'graphql'
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
@@ -1656,16 +1656,16 @@ const Feed3DocumentString = print(Feed3Document);
 const Feed4DocumentString = print(Feed4Document);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: FeedQuery; extensions?: unknown; headers: Dom.Headers; status: number; }> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: FeedQuery; extensions?: unknown; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<FeedQuery>(FeedDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed2Query; extensions?: unknown; headers: Dom.Headers; status: number; }> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed2Query; extensions?: unknown; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed2Query>(Feed2DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed3Query; extensions?: unknown; headers: Dom.Headers; status: number; }> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed3Query; extensions?: unknown; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed3Query>(Feed3DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed4Query; extensions?: unknown; headers: Dom.Headers; status: number; }> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed4Query; extensions?: unknown; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed4Query>(Feed4DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };
@@ -1697,7 +1697,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import { print } from 'graphql'
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
@@ -1940,16 +1940,16 @@ const Feed3DocumentString = print(Feed3Document);
 const Feed4DocumentString = print(Feed4Document);
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: FeedQuery; extensions?: any; headers: Dom.Headers; status: number; }> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: FeedQuery; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<FeedQuery>(FeedDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed2Query; extensions?: any; headers: Dom.Headers; status: number; }> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed2Query; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed2Query>(Feed2DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed3Query; extensions?: any; headers: Dom.Headers; status: number; }> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed3Query; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed3Query>(Feed3DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<{ data: Feed4Query; extensions?: any; headers: Dom.Headers; status: number; }> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: Feed4Query; extensions?: any; headers: Dom.Headers; status: number; }> {
         return withWrapper((wrappedRequestHeaders) => client.rawRequest<Feed4Query>(Feed4DocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };
@@ -1981,7 +1981,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import type { GraphQLClient } from 'graphql-request';
-import type * as Dom from 'graphql-request/dist/types.dom';
+import type { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -2220,16 +2220,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FeedQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed2Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed3Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed4Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };
@@ -2261,7 +2261,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 import { GraphQLClient } from 'graphql-request';
-import * as Dom from 'graphql-request/dist/types.dom';
+import { GraphQLClientRequestHeaders } from 'graphql-request/build/cjs/types';
 import gql from 'graphql-tag';
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -2500,16 +2500,16 @@ const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationTy
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    feed(variables?: FeedQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FeedQuery> {
+    feed(variables?: FeedQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FeedQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FeedQuery>(FeedDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed', 'query');
     },
-    feed2(variables: Feed2QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed2Query> {
+    feed2(variables: Feed2QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed2Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed2Query>(Feed2Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed2', 'query');
     },
-    feed3(variables?: Feed3QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed3Query> {
+    feed3(variables?: Feed3QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed3Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed3Query>(Feed3Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed3', 'query');
     },
-    feed4(variables?: Feed4QueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Feed4Query> {
+    feed4(variables?: Feed4QueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<Feed4Query> {
       return withWrapper((wrappedRequestHeaders) => client.request<Feed4Query>(Feed4Document, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'feed4', 'query');
     }
   };


### PR DESCRIPTION
## Description

Updates `@graphql-codegen/typescript-graphql-request` to support graphql-request 6+.

Note that this is a breaking change.

Related #331

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests have been updated
- [X] Tested functionality in my own project

**Test Environment**:

- OS: MacOS 13.3.1
- NodeJS: 18

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
