### PR TITLE
improve GraphCacheConfig type in urql-graphcache plugin

### DIFF
--- a/.changeset/spotty-poems-carry.md
+++ b/.changeset/spotty-poems-carry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql-graphcache': patch
+---
+
+Make `GraphCacheConfig` type rely on offlineExchange function signature for more up-to-date typings

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -1,11 +1,10 @@
 import { IntrospectionQuery } from 'graphql';
 import gql from 'graphql-tag';
 import * as Urql from 'urql';
+import { offlineExchange } from '@urql/exchange-graphcache';
 import {
-  CacheExchangeOpts,
   OptimisticMutationResolver as GraphCacheOptimisticMutationResolver,
   Resolver as GraphCacheResolver,
-  StorageAdapter as GraphCacheStorageAdapter,
   UpdateResolver as GraphCacheUpdateResolver,
 } from '@urql/exchange-graphcache';
 
@@ -1245,11 +1244,9 @@ export type GraphCacheUpdaters = {
   };
 };
 
-export type GraphCacheConfig = {
-  schema?: CacheExchangeOpts['schema'];
+export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
   updates?: GraphCacheUpdaters;
   keys?: GraphCacheKeysConfig;
   optimistic?: GraphCacheOptimisticUpdaters;
   resolvers?: GraphCacheResolvers;
-  storage?: GraphCacheStorageAdapter;
 };

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -246,9 +246,12 @@ function getOptimisticUpdatersConfig(
 }
 
 function getImports(config: UrqlGraphCacheConfig): string {
-  return `${
-    config.useTypeImports ? 'import type' : 'import'
-  } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';\n`;
+  return [
+    'import { offlineExchange } from "@urql/exchange-graphcache";',
+    `${
+      config.useTypeImports ? 'import type' : 'import'
+    } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';\n`,
+  ].join('\n');
 }
 
 export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOutput> = (
@@ -287,13 +290,11 @@ export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOut
         (subscriptionUpdaters ? `{\n    ${subscriptionUpdaters.join(',\n    ')}\n  }` : '{}') +
         ',\n};',
 
-      'export type GraphCacheConfig = {\n' +
-        "  schema?: CacheExchangeOpts['schema'],\n" +
+      'export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {\n' +
         '  updates?: GraphCacheUpdaters,\n' +
         '  keys?: GraphCacheKeysConfig,\n' +
         '  optimistic?: GraphCacheOptimisticUpdaters,\n' +
         '  resolvers?: GraphCacheResolvers,\n' +
-        '  storage?: GraphCacheStorageAdapter\n' +
         '};',
     ]
       .filter(Boolean)

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -247,7 +247,7 @@ function getOptimisticUpdatersConfig(
 
 function getImports(config: UrqlGraphCacheConfig): string {
   return [
-    'import { offlineExchange } from "@urql/exchange-graphcache";',
+    "import { offlineExchange } from '@urql/exchange-graphcache';",
     `${
       config.useTypeImports ? 'import type' : 'import'
     } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';\n`,

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -250,7 +250,7 @@ function getImports(config: UrqlGraphCacheConfig): string {
     'import { offlineExchange } from "@urql/exchange-graphcache";',
     `${
       config.useTypeImports ? 'import type' : 'import'
-    } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';\n`,
+    } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';\n`,
   ].join('\n');
 }
 

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`urql graphcache Should correctly name GraphCacheResolvers & GraphCacheOptimisticUpdaters with nonstandard mutationType names 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';
+"import { offlineExchange } from '@urql/exchange-graphcache';
+import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
@@ -31,18 +32,17 @@ export type GraphCacheUpdaters = {
   Subscription?: {},
 };
 
-export type GraphCacheConfig = {
-  schema?: CacheExchangeOpts['schema'],
+export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
   resolvers?: GraphCacheResolvers,
-  storage?: GraphCacheStorageAdapter
 };"
 `;
 
 exports[`urql graphcache Should correctly output GraphCacheOptimisticUpdaters when there are no mutations 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';
+"import { offlineExchange } from '@urql/exchange-graphcache';
+import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
@@ -68,18 +68,17 @@ export type GraphCacheUpdaters = {
   Subscription?: {},
 };
 
-export type GraphCacheConfig = {
-  schema?: CacheExchangeOpts['schema'],
+export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
   resolvers?: GraphCacheResolvers,
-  storage?: GraphCacheStorageAdapter
 };"
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly (with interfaces) 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';
+"import { offlineExchange } from '@urql/exchange-graphcache';
+import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
@@ -120,18 +119,17 @@ export type GraphCacheUpdaters = {
   Subscription?: {},
 };
 
-export type GraphCacheConfig = {
-  schema?: CacheExchangeOpts['schema'],
+export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
   resolvers?: GraphCacheResolvers,
-  storage?: GraphCacheStorageAdapter
 };"
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly (with typesPrefix and typesSuffix) 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';
+"import { offlineExchange } from '@urql/exchange-graphcache';
+import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
@@ -177,18 +175,17 @@ export type GraphCacheUpdaters = {
   Subscription?: {},
 };
 
-export type GraphCacheConfig = {
-  schema?: CacheExchangeOpts['schema'],
+export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
   resolvers?: GraphCacheResolvers,
-  storage?: GraphCacheStorageAdapter
 };"
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly (with unions) 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';
+"import { offlineExchange } from '@urql/exchange-graphcache';
+import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
@@ -224,18 +221,17 @@ export type GraphCacheUpdaters = {
   Subscription?: {},
 };
 
-export type GraphCacheConfig = {
-  schema?: CacheExchangeOpts['schema'],
+export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
   resolvers?: GraphCacheResolvers,
-  storage?: GraphCacheStorageAdapter
 };"
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly 1`] = `
-"import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';
+"import { offlineExchange } from '@urql/exchange-graphcache';
+import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
@@ -281,12 +277,10 @@ export type GraphCacheUpdaters = {
   Subscription?: {},
 };
 
-export type GraphCacheConfig = {
-  schema?: CacheExchangeOpts['schema'],
+export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
   resolvers?: GraphCacheResolvers,
-  storage?: GraphCacheStorageAdapter
 };"
 `;

--- a/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
@@ -165,9 +165,10 @@ describe('urql graphcache', () => {
     `);
     const result = mergeOutputs([await plugin(schema, [], { useTypeImports: true })]);
 
-    expect(result).toBeSimilarStringTo(
-      `import type { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, StorageAdapter as GraphCacheStorageAdapter, CacheExchangeOpts } from '@urql/exchange-graphcache';`,
-    );
+    expect(result).toBeSimilarStringTo(`\
+import { offlineExchange } from '@urql/exchange-graphcache';
+import type { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
+`);
   });
 
   it('Should correctly name GraphCacheResolvers & GraphCacheOptimisticUpdaters with nonstandard mutationType names', async () => {


### PR DESCRIPTION
Related: https://github.com/dotansimha/graphql-code-generator-community/issues/337

`storage` is non-optional (based on types) in the latest offline exchange, so I changed the generated type to relay on the function signature. At first I wanted to import `OfflineExchangeOpts` from `@urql/exchange-graphcache` but 1) it's currently not exported, 2) even if it was, it wasn't available in lower versions (and this plugin supports lower versions —based on peerDeps).

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
