### PR TITLE
feat: add plugin graphql-request-seperate-export

### DIFF
--- a/packages/plugins/typescript/graphql-request-seperate-export/jest.config.js
+++ b/packages/plugins/typescript/graphql-request-seperate-export/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../../jest.project')({ dirname: __dirname });

--- a/packages/plugins/typescript/graphql-request-seperate-export/package.json
+++ b/packages/plugins/typescript/graphql-request-seperate-export/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@graphql-codegen/typescript-graphql-request-seperate-export",
+  "version": "1.0.0",
+  "description": "GraphQL Code Generator plugin for generating a ready-to-use SDK based on graphql-request and GraphQL operations",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dotansimha/graphql-code-generator-community.git",
+    "directory": "packages/plugins/typescript/graphql-request-seperate-export"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">= 16.0.0"
+  },
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/typings/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "default": {
+        "types": "./dist/typings/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "typings": "dist/typings/index.d.ts",
+  "scripts": {
+    "lint": "eslint **/*.ts",
+    "test": "jest --no-watchman --config ../../../../jest.config.js"
+  },
+  "peerDependencies": {
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+    "graphql-request": "^6.0.0",
+    "graphql-tag": "^2.0.0"
+  },
+  "dependencies": {
+    "@graphql-codegen/plugin-helpers": "^3.0.0",
+    "@graphql-codegen/visitor-plugin-common": "2.13.1",
+    "auto-bind": "~4.0.0",
+    "tslib": "~2.4.0"
+  },
+  "devDependencies": {
+    "@graphql-codegen/testing": "1.18.0",
+    "@graphql-tools/schema": "10.0.0",
+    "graphql-request": "6.0.0"
+  },
+  "publishConfig": {
+    "directory": "dist",
+    "access": "public"
+  },
+  "typescript": {
+    "definition": "dist/typings/index.d.ts"
+  }
+}

--- a/packages/plugins/typescript/graphql-request-seperate-export/src/config.ts
+++ b/packages/plugins/typescript/graphql-request-seperate-export/src/config.ts
@@ -1,0 +1,37 @@
+import {
+  ClientSideBasePluginConfig,
+  RawClientSideBasePluginConfig,
+} from '@graphql-codegen/visitor-plugin-common';
+
+export type PluginConfig = {
+  /**
+   * example: `import { client } from '../your-graphql-client';`
+   *
+   * the imported `client` should be an instance of graphql-client
+   */
+  importGraphQLClientStatment: string;
+
+  /**
+   * @description By default the `request` method return the `data` or `errors` key from the response. If you need to access the `extensions` key you can use the `rawRequest` method.
+   *
+   * @exampleMarkdown
+   * ```yaml
+   * generates:
+   * path/to/file.ts:
+   *  plugins:
+   *    - typescript
+   *    - typescript-operations
+   *    - typescript-graphql-request-seperate-export
+   *  config:
+   *    rawRequest: true
+   *    pureMagicComment: true
+   * ```
+   */
+  rawRequest?: boolean;
+};
+
+/**
+ * This plugin generate a some request seperate export function with graphql-request, allow you to easily customize the way you fetch your data, without loosing the strongly-typed integration.
+ */
+export type RawGraphQLSeperateExportPluginConfig = RawClientSideBasePluginConfig & PluginConfig;
+export type GraphQLSeperateExportPluginConfig = ClientSideBasePluginConfig & PluginConfig;

--- a/packages/plugins/typescript/graphql-request-seperate-export/src/index.ts
+++ b/packages/plugins/typescript/graphql-request-seperate-export/src/index.ts
@@ -1,0 +1,57 @@
+import { extname } from 'path';
+import { concatAST, FragmentDefinitionNode, GraphQLSchema, Kind } from 'graphql';
+import { DocumentNode } from 'graphql';
+import { oldVisit, PluginFunction, PluginValidateFn, Types } from '@graphql-codegen/plugin-helpers';
+import {
+  LoadedFragment,
+  RawClientSideBasePluginConfig,
+} from '@graphql-codegen/visitor-plugin-common';
+import { RawGraphQLSeperateExportPluginConfig } from './config';
+import { GraphQLRequestSeperateExportVisitor } from './visitor';
+
+export const plugin: PluginFunction<RawGraphQLSeperateExportPluginConfig> = (
+  schema: GraphQLSchema,
+  documents: Types.DocumentFile[],
+  config: RawGraphQLSeperateExportPluginConfig,
+) => {
+  const allAst = concatAST(documents.map(v => v.document));
+  const allFragments: LoadedFragment[] = [
+    ...(
+      allAst.definitions.filter(
+        d => d.kind === Kind.FRAGMENT_DEFINITION,
+      ) as FragmentDefinitionNode[]
+    ).map(fragmentDef => ({
+      node: fragmentDef,
+      name: fragmentDef.name.value,
+      onType: fragmentDef.typeCondition.name.value,
+      isExternal: false,
+    })),
+    ...(config.externalFragments || []),
+  ];
+  const visitor = new GraphQLRequestSeperateExportVisitor(schema, allFragments, config);
+  const visitorResult = oldVisit(allAst, { leave: visitor }) as DocumentNode;
+
+  return {
+    prepend: visitor.getImports(),
+    content: [
+      visitor.fragments,
+      ...visitorResult.definitions.filter(t => typeof t === 'string'),
+      visitor.sdkContent,
+    ].join('\n'),
+  };
+};
+
+export const validate: PluginValidateFn<any> = async (
+  _schema: GraphQLSchema,
+  _documents: Types.DocumentFile[],
+  _config: RawClientSideBasePluginConfig,
+  outputFile: string,
+) => {
+  if (extname(outputFile) !== '.ts') {
+    throw new Error(
+      `Plugin "typescript-graphql-request-seperate-export" requires extension to be ".ts"!`,
+    );
+  }
+};
+
+export { GraphQLRequestSeperateExportVisitor };

--- a/packages/plugins/typescript/graphql-request-seperate-export/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request-seperate-export/src/visitor.ts
@@ -1,0 +1,99 @@
+import autoBind from 'auto-bind';
+import { GraphQLSchema, Kind, OperationDefinitionNode, print } from 'graphql';
+import {
+  ClientSideBaseVisitor,
+  DocumentMode,
+  getConfigValue,
+  LoadedFragment,
+} from '@graphql-codegen/visitor-plugin-common';
+import { GraphQLSeperateExportPluginConfig, RawGraphQLSeperateExportPluginConfig } from './config';
+
+export class GraphQLRequestSeperateExportVisitor extends ClientSideBaseVisitor<
+  RawGraphQLSeperateExportPluginConfig,
+  GraphQLSeperateExportPluginConfig
+> {
+  private _operationsToInclude: {
+    node: OperationDefinitionNode;
+    documentVariableName: string;
+    operationType: string;
+    operationResultType: string;
+    operationVariablesTypes: string;
+  }[] = [];
+
+  constructor(
+    schema: GraphQLSchema,
+    fragments: LoadedFragment[],
+    rawConfig: RawGraphQLSeperateExportPluginConfig,
+  ) {
+    if (!rawConfig.importGraphQLClientStatment) {
+      throw new Error(
+        "Plugin 'graphql-request-seperate-export' need `importGraphQLClientStatment`.",
+      );
+    }
+    super(schema, fragments, rawConfig, {
+      rawRequest: getConfigValue(rawConfig.rawRequest, false),
+      importGraphQLClientStatment: rawConfig.importGraphQLClientStatment,
+    });
+    autoBind(this);
+    this._additionalImports.push("import { GraphQLClient } from 'graphql-request';");
+    this._additionalImports.push(this.config.importGraphQLClientStatment);
+    if (this.config.documentMode !== DocumentMode.string) {
+      const importType = this.config.useTypeImports ? 'import type' : 'import';
+      this._additionalImports.push(`${importType} { DocumentNode } from 'graphql';`);
+    }
+  }
+
+  protected buildOperation(
+    node: OperationDefinitionNode,
+    documentVariableName: string,
+    operationType: string,
+    operationResultType: string,
+    operationVariablesTypes: string,
+  ): string {
+    if (node.name == null) {
+      throw new Error(
+        "Plugin 'graphql-request-seperate-export' cannot generate request functions for unnamed operation.\n\n" +
+          print(node),
+      );
+    } else {
+      this._operationsToInclude.push({
+        node,
+        documentVariableName,
+        operationType,
+        operationResultType,
+        operationVariablesTypes,
+      });
+    }
+
+    return null;
+  }
+
+  public get sdkContent(): string {
+    const pureMagicComment = this.config.pureMagicComment;
+    const rawRequest = this.config.rawRequest;
+    const allPossibleActions = this._operationsToInclude.map(o => {
+      const optionalVariables =
+        !o.node.variableDefinitions ||
+        o.node.variableDefinitions.length === 0 ||
+        o.node.variableDefinitions.every(v => v.type.kind !== Kind.NON_NULL_TYPE || v.defaultValue);
+      const functionName = o.node.name.value;
+      const resultDataTypeName = `${functionName[0].toUpperCase()}${functionName.slice(
+        1,
+      )}ReturnType`;
+      const resultDataType = rawRequest
+        ? `{ data?: ${o.operationResultType}, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }`
+        : o.operationResultType;
+      return `
+export type ${resultDataTypeName} = ${resultDataType}\n
+export const ${functionName} = ${pureMagicComment ? '/*#__PURE__*/' : ''}async (variables${
+        optionalVariables ? '?' : ''
+      }: ${o.operationVariablesTypes}, options?: C): Promise<${resultDataTypeName}> => {
+  return client.${rawRequest ? 'rawRequest' : 'request'}<${o.operationResultType}, ${
+        o.operationVariablesTypes
+      }>(${o.documentVariableName}, variables, options) as Promise<${resultDataTypeName}>;
+}`;
+    });
+
+    return `${allPossibleActions.join('\n')}`;
+  }
+}

--- a/packages/plugins/typescript/graphql-request-seperate-export/tests/__snapshots__/graphql-request-seperate-export.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request-seperate-export/tests/__snapshots__/graphql-request-seperate-export.spec.ts.snap
@@ -1,0 +1,834 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`graphql-request-seperate-export generate split request function Should generate a correct wrap method 1`] = `
+"export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+import { GraphQLClient } from 'graphql-request';
+import { client } from "./my-graphql-request"
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP'
+}
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
+/**
+ * A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL'
+}
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
+
+export type Feed2QueryVariables = Exact<{
+  v: Scalars['String'];
+}>;
+
+
+export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export type Feed3QueryVariables = Exact<{
+  v?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export type Feed4QueryVariables = Exact<{
+  v?: Scalars['String'];
+}>;
+
+
+export type Feed4Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export const FeedDocument = /*#__PURE__*/ gql\`
+    query feed {
+  feed {
+    id
+    commentCount
+    repository {
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const Feed2Document = /*#__PURE__*/ gql\`
+    query feed2($v: String!) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed3Document = /*#__PURE__*/ gql\`
+    query feed3($v: String) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed4Document = /*#__PURE__*/ gql\`
+    query feed4($v: String! = "TEST") {
+  feed {
+    id
+  }
+}
+    \`;
+
+export type FeedReturnType = FeedQuery
+
+export const feed = /*#__PURE__*/async (variables?: FeedQueryVariables, options?: C): Promise<FeedReturnType> => {
+  return client.request<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedReturnType>;
+}
+
+export type Feed2ReturnType = Feed2Query
+
+export const feed2 = /*#__PURE__*/async (variables: Feed2QueryVariables, options?: C): Promise<Feed2ReturnType> => {
+  return client.request<Feed2Query, Feed2QueryVariables>(Feed2Document, variables, options) as Promise<Feed2ReturnType>;
+}
+
+export type Feed3ReturnType = Feed3Query
+
+export const feed3 = /*#__PURE__*/async (variables?: Feed3QueryVariables, options?: C): Promise<Feed3ReturnType> => {
+  return client.request<Feed3Query, Feed3QueryVariables>(Feed3Document, variables, options) as Promise<Feed3ReturnType>;
+}
+
+export type Feed4ReturnType = Feed4Query
+
+export const feed4 = /*#__PURE__*/async (variables?: Feed4QueryVariables, options?: C): Promise<Feed4ReturnType> => {
+  return client.request<Feed4Query, Feed4QueryVariables>(Feed4Document, variables, options) as Promise<Feed4ReturnType>;
+}
+async function test() {
+  await feed();
+  await feed3();
+  await feed4();
+
+  const result = await feed2({ v: "1" });
+
+  if (result.feed) {
+    if (result.feed[0]) {
+      const id = result.feed[0].id
+    }
+  }
+}"
+`;
+
+exports[`graphql-request-seperate-export generate split request function Should generate a correct wrap method with documentMode=string 1`] = `
+"export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+import { GraphQLClient } from 'graphql-request';
+import { client } from "./my-graphql-request"
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP'
+}
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
+/**
+ * A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL'
+}
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
+
+export type Feed2QueryVariables = Exact<{
+  v: Scalars['String'];
+}>;
+
+
+export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export type Feed3QueryVariables = Exact<{
+  v?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export type Feed4QueryVariables = Exact<{
+  v?: Scalars['String'];
+}>;
+
+
+export type Feed4Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export const FeedDocument = \`
+    query feed {
+  feed {
+    id
+    commentCount
+    repository {
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const Feed2Document = \`
+    query feed2($v: String!) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed3Document = \`
+    query feed3($v: String) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed4Document = \`
+    query feed4($v: String! = "TEST") {
+  feed {
+    id
+  }
+}
+    \`;
+
+export type FeedReturnType = FeedQuery
+
+export const feed = async (variables?: FeedQueryVariables, options?: C): Promise<FeedReturnType> => {
+  return client.request<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedReturnType>;
+}
+
+export type Feed2ReturnType = Feed2Query
+
+export const feed2 = async (variables: Feed2QueryVariables, options?: C): Promise<Feed2ReturnType> => {
+  return client.request<Feed2Query, Feed2QueryVariables>(Feed2Document, variables, options) as Promise<Feed2ReturnType>;
+}
+
+export type Feed3ReturnType = Feed3Query
+
+export const feed3 = async (variables?: Feed3QueryVariables, options?: C): Promise<Feed3ReturnType> => {
+  return client.request<Feed3Query, Feed3QueryVariables>(Feed3Document, variables, options) as Promise<Feed3ReturnType>;
+}
+
+export type Feed4ReturnType = Feed4Query
+
+export const feed4 = async (variables?: Feed4QueryVariables, options?: C): Promise<Feed4ReturnType> => {
+  return client.request<Feed4Query, Feed4QueryVariables>(Feed4Document, variables, options) as Promise<Feed4ReturnType>;
+}
+async function test() {
+  await feed();
+  await feed3();
+  await feed4();
+
+  const result = await feed2({ v: "1" });
+
+  if (result.feed) {
+    if (result.feed[0]) {
+      const id = result.feed[0].id
+    }
+  }
+}"
+`;
+
+exports[`graphql-request-seperate-export generate split request function Should support rawRequest 1`] = `
+"export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+import { GraphQLClient } from 'graphql-request';
+import { client } from "./my-graphql-request"
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** A feed of repository submissions */
+  feed?: Maybe<Array<Maybe<Entry>>>;
+  /** A single entry */
+  entry?: Maybe<Entry>;
+  /** Return the currently logged in user, or null if nobody is logged in */
+  currentUser?: Maybe<User>;
+};
+
+
+export type QueryFeedArgs = {
+  type: FeedType;
+  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type QueryEntryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+/** A list of options for the sort order of the feed */
+export enum FeedType {
+  /** Sort by a combination of freshness and score, using Reddit's algorithm */
+  Hot = 'HOT',
+  /** Newest entries first */
+  New = 'NEW',
+  /** Highest score entries first */
+  Top = 'TOP'
+}
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type Entry = {
+  __typename?: 'Entry';
+  /** Information about the repository from GitHub */
+  repository: Repository;
+  /** The GitHub user who submitted this entry */
+  postedBy: User;
+  /** A timestamp of when the entry was submitted */
+  createdAt: Scalars['Float'];
+  /** The score of this repository, upvotes - downvotes */
+  score: Scalars['Int'];
+  /** The hot score of this repository */
+  hotScore: Scalars['Float'];
+  /** Comments posted about this repository */
+  comments: Array<Maybe<Comment>>;
+  /** The number of comments posted about this repository */
+  commentCount: Scalars['Int'];
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** XXX to be changed */
+  vote: Vote;
+};
+
+
+/** Information about a GitHub repository submitted to GitHunt */
+export type EntryCommentsArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
+/**
+ * A repository object from the GitHub API. This uses the exact field names returned by the
+ * GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+ */
+export type Repository = {
+  __typename?: 'Repository';
+  /** Just the name of the repository, e.g. GitHunt-API */
+  name: Scalars['String'];
+  /** The full name of the repository with the username, e.g. apollostack/GitHunt-API */
+  full_name: Scalars['String'];
+  /** The description of the repository */
+  description?: Maybe<Scalars['String']>;
+  /** The link to the repository on GitHub */
+  html_url: Scalars['String'];
+  /** The number of people who have starred this repository on GitHub */
+  stargazers_count: Scalars['Int'];
+  /** The number of open issues on this repository on GitHub */
+  open_issues_count?: Maybe<Scalars['Int']>;
+  /** The owner of this repository on GitHub, e.g. apollostack */
+  owner?: Maybe<User>;
+};
+
+/** A user object from the GitHub API. This uses the exact field names returned from the GitHub API. */
+export type User = {
+  __typename?: 'User';
+  /** The name of the user, e.g. apollostack */
+  login: Scalars['String'];
+  /** The URL to a directly embeddable image for this user's avatar */
+  avatar_url: Scalars['String'];
+  /** The URL of this user's GitHub page */
+  html_url: Scalars['String'];
+};
+
+/** A comment about an entry, submitted by a user */
+export type Comment = {
+  __typename?: 'Comment';
+  /** The SQL ID of this entry */
+  id: Scalars['Int'];
+  /** The GitHub user who posted the comment */
+  postedBy: User;
+  /** A timestamp of when the comment was posted */
+  createdAt: Scalars['Float'];
+  /** The text of the comment */
+  content: Scalars['String'];
+  /** The repository which this comment is about */
+  repoName: Scalars['String'];
+};
+
+/** XXX to be removed */
+export type Vote = {
+  __typename?: 'Vote';
+  vote_value: Scalars['Int'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Submit a new repository, returns the new submission */
+  submitRepository?: Maybe<Entry>;
+  /** Vote on a repository submission, returns the submission that was voted on */
+  vote?: Maybe<Entry>;
+  /** Comment on a repository, returns the new comment */
+  submitComment?: Maybe<Comment>;
+};
+
+
+export type MutationSubmitRepositoryArgs = {
+  repoFullName: Scalars['String'];
+};
+
+
+export type MutationVoteArgs = {
+  repoFullName: Scalars['String'];
+  type: VoteType;
+};
+
+
+export type MutationSubmitCommentArgs = {
+  repoFullName: Scalars['String'];
+  commentContent: Scalars['String'];
+};
+
+/** The type of vote to record, when submitting a vote */
+export enum VoteType {
+  Up = 'UP',
+  Down = 'DOWN',
+  Cancel = 'CANCEL'
+}
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** Subscription fires on every comment added */
+  commentAdded?: Maybe<Comment>;
+};
+
+
+export type SubscriptionCommentAddedArgs = {
+  repoFullName: Scalars['String'];
+};
+export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
+
+export type Feed2QueryVariables = Exact<{
+  v: Scalars['String'];
+}>;
+
+
+export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export type Feed3QueryVariables = Exact<{
+  v?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export type Feed4QueryVariables = Exact<{
+  v?: Scalars['String'];
+}>;
+
+
+export type Feed4Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
+
+export const FeedDocument = gql\`
+    query feed {
+  feed {
+    id
+    commentCount
+    repository {
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+export const Feed2Document = gql\`
+    query feed2($v: String!) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed3Document = gql\`
+    query feed3($v: String) {
+  feed {
+    id
+  }
+}
+    \`;
+export const Feed4Document = gql\`
+    query feed4($v: String! = "TEST") {
+  feed {
+    id
+  }
+}
+    \`;
+
+export type FeedReturnType = { data?: FeedQuery, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }
+
+export const feed = async (variables?: FeedQueryVariables, options?: C): Promise<FeedReturnType> => {
+  return client.rawRequest<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedReturnType>;
+}
+
+export type Feed2ReturnType = { data?: Feed2Query, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }
+
+export const feed2 = async (variables: Feed2QueryVariables, options?: C): Promise<Feed2ReturnType> => {
+  return client.rawRequest<Feed2Query, Feed2QueryVariables>(Feed2Document, variables, options) as Promise<Feed2ReturnType>;
+}
+
+export type Feed3ReturnType = { data?: Feed3Query, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }
+
+export const feed3 = async (variables?: Feed3QueryVariables, options?: C): Promise<Feed3ReturnType> => {
+  return client.rawRequest<Feed3Query, Feed3QueryVariables>(Feed3Document, variables, options) as Promise<Feed3ReturnType>;
+}
+
+export type Feed4ReturnType = { data?: Feed4Query, errors?: Array<{ message: string; extensions?: unknown }>, extensions?: unknown }
+
+export const feed4 = async (variables?: Feed4QueryVariables, options?: C): Promise<Feed4ReturnType> => {
+  return client.rawRequest<Feed4Query, Feed4QueryVariables>(Feed4Document, variables, options) as Promise<Feed4ReturnType>;
+}
+        async function rawRequestTest() {
+          await feed();
+          await feed3();
+          await feed4();
+
+          const result = await feed2({ v: "1" });
+
+          if (result.data.feed) {
+            if (result.data.feed[0]) {
+              const id = result.data.feed[0].id
+            }
+          }
+        }
+      "
+`;

--- a/packages/plugins/typescript/graphql-request-seperate-export/tests/graphql-request-seperate-export.spec.ts
+++ b/packages/plugins/typescript/graphql-request-seperate-export/tests/graphql-request-seperate-export.spec.ts
@@ -1,0 +1,190 @@
+import { buildClientSchema, GraphQLSchema, parse } from 'graphql';
+import { mergeOutputs, Types } from '@graphql-codegen/plugin-helpers';
+import { validateTs } from '@graphql-codegen/testing';
+import { plugin as tsPlugin, TypeScriptPluginConfig } from '@graphql-codegen/typescript';
+import {
+  plugin as tsDocumentsPlugin,
+  TypeScriptDocumentsPluginConfig,
+} from '@graphql-codegen/typescript-operations';
+import { DocumentMode } from '@graphql-codegen/visitor-plugin-common';
+import { RawGraphQLSeperateExportPluginConfig } from '../src/config';
+import { plugin } from '../src/index';
+
+const schema = buildClientSchema(require('../../../../../dev-test/githunt/schema.json'));
+const basicDoc = parse(/* GraphQL */ `
+  query feed {
+    feed {
+      id
+      commentCount
+      repository {
+        owner {
+          avatar_url
+        }
+      }
+    }
+  }
+
+  query feed2($v: String!) {
+    feed {
+      id
+    }
+  }
+
+  query feed3($v: String) {
+    feed {
+      id
+    }
+  }
+
+  query feed4($v: String! = "TEST") {
+    feed {
+      id
+    }
+  }
+`);
+
+const unnamedDoc = parse(/* GraphQL */ `
+  {
+    feed {
+      id
+    }
+  }
+`);
+
+const validate = async (
+  content: Types.PluginOutput,
+  config: TypeScriptPluginConfig &
+    TypeScriptDocumentsPluginConfig &
+    RawGraphQLSeperateExportPluginConfig,
+  docs: Types.DocumentFile[],
+  pluginSchema: GraphQLSchema,
+  usage: string,
+) => {
+  const m = mergeOutputs([
+    await tsPlugin(pluginSchema, docs, config, { outputFile: '' }),
+    await tsDocumentsPlugin(pluginSchema, docs, config, { outputFile: '' }),
+    content,
+    usage,
+  ]);
+
+  validateTs(m, {
+    allowSyntheticDefaultImports: true,
+  });
+
+  return m;
+};
+
+const importGraphQLClientStatment = 'import { client } from "./my-graphql-request"';
+
+describe('graphql-request-seperate-export', () => {
+  describe('generate split request function', () => {
+    it('Should generate a correct wrap method', async () => {
+      const config = {
+        importGraphQLClientStatment,
+        pureMagicComment: true,
+      };
+      const docs = [{ filePath: '', document: basicDoc }];
+      const result = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      const usage = `
+async function test() {
+  await feed();
+  await feed3();
+  await feed4();
+
+  const result = await feed2({ v: "1" });
+
+  if (result.feed) {
+    if (result.feed[0]) {
+      const id = result.feed[0].id
+    }
+  }
+}`;
+      const output = await validate(result, config, docs, schema, usage);
+
+      expect(output).toMatchSnapshot();
+    });
+
+    it('Should generate a correct wrap method with documentMode=string', async () => {
+      const config = {
+        importGraphQLClientStatment,
+        documentMode: DocumentMode.string,
+      };
+      const docs = [{ filePath: '', document: basicDoc }];
+      const result = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      const usage = `
+async function test() {
+  await feed();
+  await feed3();
+  await feed4();
+
+  const result = await feed2({ v: "1" });
+
+  if (result.feed) {
+    if (result.feed[0]) {
+      const id = result.feed[0].id
+    }
+  }
+}`;
+      const output = await validate(result, config, docs, schema, usage);
+
+      expect(output).toMatchSnapshot();
+    });
+
+    it('Should support rawRequest', async () => {
+      const config = {
+        importGraphQLClientStatment,
+        rawRequest: true,
+      };
+      const docs = [{ filePath: '', document: basicDoc }];
+      const result = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput;
+
+      const usage = `
+        async function rawRequestTest() {
+          await feed();
+          await feed3();
+          await feed4();
+
+          const result = await feed2({ v: "1" });
+
+          if (result.data.feed) {
+            if (result.data.feed[0]) {
+              const id = result.data.feed[0].id
+            }
+          }
+        }
+      `;
+      const output = await validate(result, config, docs, schema, usage);
+
+      expect(output).toMatchSnapshot();
+    });
+
+    it('Should throw if it encounters unnamed operations', async () => {
+      const config = {
+        importGraphQLClientStatment,
+      };
+      const docs = [{ filePath: '', document: unnamedDoc }];
+      try {
+        await plugin(schema, docs, config, { outputFile: 'graphql.ts' });
+        fail('Should throw');
+      } catch (err: unknown) {
+        expect(err).toMatchInlineSnapshot(`
+          [Error: Plugin 'graphql-request-seperate-export' cannot generate request functions for unnamed operation.
+
+          {
+            feed {
+              id
+            }
+          }]
+        `);
+      }
+    });
+  });
+});


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Related # (issue)

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] yarn test
- [x] yarn build

**Test Environment**:

- OS:ubuntu 22
- `@graphql-codegen/...`:
- NodeJS: 18.16.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
I have used @graphql-codegen/typescript-graphql-request, but the object generated by it is a large object, each method is a request funciton, it works but can not be treeshaked.
I would like to use seperated export for each request function, the functions are not related to each other so they can be treeshaked.

I have read the contributing doc. I am confused in step 10.
`website/src/pages/plugins/` dir is in graphql-code-generator, will it be moved to graphql-code-generator-community ?