### PR TITLE
feat: [typescript-react-query] Able to import useQuery from own-path instead react-query or tanstack/react-query

### DIFF
--- a/.changeset/hot-tools-destroy.md
+++ b/.changeset/hot-tools-destroy.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Provide reactQueryImportFrom field to custom react-query import from

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -116,7 +116,12 @@ export interface ReactQueryRawPluginConfig
 
   /**
    * @default empty
-   * @description Add custom import for react-query. It can be used to import from `@tanstack/react-query` instead of `react-query`. But make sure it include useQuery, UseQueryOptions, useMutation, UseMutationOptions, useInfiniteQuery, UseInfiniteQueryOptions
+   * @description Add custom import for react-query.
+   * It can be used to import from `@tanstack/react-query` instead of `react-query`. But make sure it include useQuery, UseQueryOptions, useMutation, UseMutationOptions, useInfiniteQuery, UseInfiniteQueryOptions
+   *
+   * The following options are available to use:
+   *
+   * - "src/your-own-react-query-customized": import { useQuery, UseQueryOptions, useMutation, UseMutationOptions, useInfiniteQuery, UseInfiniteQueryOptions } from your own react-query customized package.
    */
   reactQueryImportFrom?: string;
 }

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -113,4 +113,10 @@ export interface ReactQueryRawPluginConfig
    * @description If false, it will work with `@tanstack/react-query`, default value is true.
    */
   legacyMode?: boolean;
+
+  /**
+   * @default empty
+   * @description Add custom import for react-query. It can be used to import from `@tanstack/react-query` instead of `react-query`. But make sure it include useQuery, UseQueryOptions, useMutation, UseMutationOptions, useInfiniteQuery, UseInfiniteQueryOptions
+   */
+  reactQueryImportFrom?: string;
 }

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -32,6 +32,7 @@ export interface ReactQueryPluginConfig extends ClientSideBasePluginConfig {
   exposeFetcher: boolean;
   addInfiniteQuery: boolean;
   legacyMode: boolean;
+  reactQueryImportFrom?: string;
 }
 
 export interface ReactQueryMethodMap {
@@ -89,6 +90,7 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
       exposeFetcher: getConfigValue(rawConfig.exposeFetcher, false),
       addInfiniteQuery: getConfigValue(rawConfig.addInfiniteQuery, false),
       legacyMode: getConfigValue(rawConfig.legacyMode, false),
+      reactQueryImportFrom: getConfigValue(rawConfig.reactQueryImportFrom, ''),
     });
     this._externalImportPrefix = this.config.importOperationTypesFrom
       ? `${this.config.importOperationTypesFrom}.`
@@ -135,7 +137,13 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
       ),
     ];
 
-    const moduleName = this.config.legacyMode ? 'react-query' : '@tanstack/react-query';
+    const moduleName = this.config.reactQueryImportFrom
+      ? this.config.reactQueryImportFrom
+      : this.config.legacyMode
+      ? 'react-query'
+      : '@tanstack/react-query';
+
+    console.log('===reactQueryImportFrom, ', this.config.reactQueryImportFrom, moduleName);
 
     return [...baseImports, `import { ${hookAndTypeImports.join(', ')} } from '${moduleName}';`];
   }

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -143,8 +143,6 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
       ? 'react-query'
       : '@tanstack/react-query';
 
-    console.log('===reactQueryImportFrom, ', this.config.reactQueryImportFrom, moduleName);
-
     return [...baseImports, `import { ${hookAndTypeImports.join(', ')} } from '${moduleName}';`];
   }
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -1378,8 +1378,12 @@ export const useTestMutation = <
         reactQueryImportFrom: 'custom-react-query',
       };
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
-      expect(out.prepend).toContain(`from 'custom-react-query';`);
-      expect(out.prepend).not.toContain(`from 'react-query';`);
+      expect(out.prepend).toContain(
+        "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'custom-react-query';",
+      );
+      expect(out.prepend).not.toContain(
+        `"import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';"`,
+      );
     });
   });
 });

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -1370,4 +1370,16 @@ export const useTestMutation = <
           });
     `);
   });
+
+  describe('reactQueryImportFrom: custom-path', () => {
+    it('Should import react-query from custom path', async () => {
+      const config = {
+        legacyMode: true,
+        reactQueryImportFrom: 'custom-react-query',
+      };
+      const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+      expect(out.prepend).toContain(`from 'custom-react-query';`);
+      expect(out.prepend).not.toContain(`from 'react-query';`);
+    });
+  });
 });


### PR DESCRIPTION
## Description

I would like to propose a new feature to address this issue. I have described the proposed solution in detail on the following GitHub discussion: [Link to GitHub Discussion](https://github.com/dotansimha/graphql-code-generator/discussions/9521).

In summary, I suggest adding a new configuration field called `reactQueryImportFrom`. This field will allow users to specify a custom import path for react-query. For example:

```
reactQueryImportFrom = 'custom-react-query';
```

With this configuration, the import statements for `useQuery, useMutation, UseQueryOptions, and UseMutationOptions` will be updated as follows:
```
import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'custom-react-query';
```

This feature will provide flexibility and enable developers to centralize the source with some required configuration, making it easier to customize and maintain their projects.

List any dependencies that are required for this change.
- typescript-react-query

Related #368 (issue)  


<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] reactQueryImportFrom: custom-path

**Test Environment**:

- OS: Ubuntu
- "@graphql-codegen/plugin-helpers": "^3.0.0",
- "@graphql-codegen/visitor-plugin-common": "2.13.1",
- NodeJS: v16.18.1

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
