### PR TITLE
fix(typescript-urql): optional options for subscription

### DIFF
--- a/.changeset/long-buses-pump.md
+++ b/.changeset/long-buses-pump.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-urql': patch
+---
+
+Generates optional or required options argument for subscriptions if variables are required or not.

--- a/packages/plugins/typescript/urql/src/visitor.ts
+++ b/packages/plugins/typescript/urql/src/visitor.ts
@@ -121,17 +121,19 @@ export function use${operationName}() {
 };`;
     }
 
-    if (operationType === 'Subscription') {
-      return `
-export function use${operationName}<TData = ${operationResultType}>(options: Omit<Urql.Use${operationType}Args<${operationVariablesTypes}>, 'query'> = {}, handler?: Urql.SubscriptionHandler<${operationResultType}, TData>) {
-  return Urql.use${operationType}<${operationResultType}, TData, ${operationVariablesTypes}>({ query: ${documentVariableName}, ...options }, handler);
-};`;
-    }
-
     const isVariablesRequired = node.variableDefinitions.some(
       variableDef =>
         variableDef.type.kind === Kind.NON_NULL_TYPE && variableDef.defaultValue == null,
     );
+
+    if (operationType === 'Subscription') {
+      return `
+export function use${operationName}<TData = ${operationResultType}>(options${
+        isVariablesRequired ? '' : '?'
+      }: Omit<Urql.Use${operationType}Args<${operationVariablesTypes}>, 'query'>, handler?: Urql.SubscriptionHandler<${operationResultType}, TData>) {
+  return Urql.use${operationType}<${operationResultType}, TData, ${operationVariablesTypes}>({ query: ${documentVariableName}, ...options }, handler);
+};`;
+    }
 
     return `
 export function use${operationName}(options${

--- a/packages/plugins/typescript/urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql/tests/__snapshots__/urql.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`urql Hooks Should generate subscription hooks 1`] = `
+exports[`urql Hooks Should generate subscription hooks with optional arguments 1`] = `
 "import gql from 'graphql-tag';
 import * as Urql from 'urql';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -13,7 +13,25 @@ export const ListenToCommentsDocument = gql\`
 }
     \`;
 
-export function useListenToCommentsSubscription<TData = ListenToCommentsSubscription>(options: Omit<Urql.UseSubscriptionArgs<ListenToCommentsSubscriptionVariables>, 'query'> = {}, handler?: Urql.SubscriptionHandler<ListenToCommentsSubscription, TData>) {
+export function useListenToCommentsSubscription<TData = ListenToCommentsSubscription>(options?: Omit<Urql.UseSubscriptionArgs<ListenToCommentsSubscriptionVariables>, 'query'>, handler?: Urql.SubscriptionHandler<ListenToCommentsSubscription, TData>) {
+  return Urql.useSubscription<ListenToCommentsSubscription, TData, ListenToCommentsSubscriptionVariables>({ query: ListenToCommentsDocument, ...options }, handler);
+};"
+`;
+
+exports[`urql Hooks Should generate subscription hooks with required arguments 1`] = `
+"import gql from 'graphql-tag';
+import * as Urql from 'urql';
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export const ListenToCommentsDocument = gql\`
+    subscription ListenToComments($name: String!) {
+  commentAdded(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+
+export function useListenToCommentsSubscription<TData = ListenToCommentsSubscription>(options: Omit<Urql.UseSubscriptionArgs<ListenToCommentsSubscriptionVariables>, 'query'>, handler?: Urql.SubscriptionHandler<ListenToCommentsSubscription, TData>) {
   return Urql.useSubscription<ListenToCommentsSubscription, TData, ListenToCommentsSubscriptionVariables>({ query: ListenToCommentsDocument, ...options }, handler);
 };"
 `;


### PR DESCRIPTION
## Description

When generating subscription, it now checks if
variables are required and generates correct
options argument to the function.

Related #372 

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I first made a yarn patch in my project to fix my issue.
In `graphql-code-generator-community` repo I added tests
to make sure it creates optional and required options if variables are required.

**Test Environment**:

- OS: Linux
- "@graphql-codegen/add": "4.0.1"
- "@graphql-codegen/cli": "3.3.1"
- "@graphql-codegen/typescript": "3.0.4"
- "@graphql-codegen/typescript-operations": "3.0.0"
- "@graphql-codegen/typescript-react-apollo": "3.3.7"
- "@graphql-codegen/typescript-urql": "3.7.3"
- "@graphql-codegen/plugin-helpers": "4.2.0"
- "@graphql-codegen/typescript-resolvers": "3.2.1"
- "@graphql-codegen/urql-introspection": "2.2.1"
- NodeJS: 16.14.2

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
