### PR TITLE
Accept skipDocumentsValidation config parameter from near-operation-file-preset

### DIFF
--- a/.changeset/thirty-books-explode.md
+++ b/.changeset/thirty-books-explode.md
@@ -1,0 +1,12 @@
+---
+'@graphql-codegen/near-operation-file-preset': major
+---
+
+accept skipDocumentsValidation config parameter
+
+‼️ ‼️ ‼️ Please note ‼️ ‼️ ‼️:
+
+This is a breaking change since previous versions skips all documents validation
+and this could raise validation errors while generating types.
+
+

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -350,7 +350,10 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
         config,
         schema: options.schema,
         schemaAst: schemaObject,
-        skipDocumentsValidation: true,
+        skipDocumentsValidation:
+          typeof options.skipDocumentsValidation === 'undefined'
+            ? { skipDuplicateValidation: true }
+            : options.skipDocumentsValidation,
       });
     }
 

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -699,7 +699,45 @@ describe('near-operation-file preset', () => {
       pluginMap: {},
     });
 
-    expect(result[0].skipDocumentsValidation).toBeTruthy();
+    expect(result[0].skipDocumentsValidation).toEqual({ skipDuplicateValidation: true });
+  });
+
+  it('Should allow to customize the skip documents validation', async () => {
+    const result = await executePreset({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      schemaAst: schemaNode,
+      documents: testDocuments,
+      plugins: [],
+      pluginMap: {},
+      skipDocumentsValidation: {
+        skipValidationAgainstSchema: true,
+      },
+    });
+
+    expect(result[0].skipDocumentsValidation).toEqual({ skipValidationAgainstSchema: true });
+  });
+
+  it('Should allow to opt-out skipping documents validation', async () => {
+    const result = await executePreset({
+      baseOutputDir: './src/',
+      config: {},
+      presetConfig: {
+        baseTypesPath: 'types.ts',
+      },
+      schema: schemaDocumentNode,
+      schemaAst: schemaNode,
+      documents: testDocuments,
+      plugins: [],
+      pluginMap: {},
+      skipDocumentsValidation: false,
+    });
+
+    expect(result[0].skipDocumentsValidation).toBe(false);
   });
 
   it('Should allow to customize output extension', async () => {


### PR DESCRIPTION
https://github.com/dotansimha/graphql-code-generator-community/issues/214

## Description

In 2019 https://github.com/dotansimha/graphql-code-generator/issues/2143 lead to https://github.com/dotansimha/graphql-code-generator/commit/1559ab682073477f5402d9231e0c91f6832af5cb. This resulted in typechecking being disabled for near-operation-file presets.

In 2022 https://github.com/dotansimha/graphql-code-generator/pull/8222 was created in the former presets repository but hasn't been created in this new repository, thanks to @klyve for that PR.

Since that change the ability to toggle this setting was introduced in: https://github.com/dotansimha/graphql-code-generator/pull/6825.

Running the same tests from https://github.com/dotansimha/graphql-code-generator/issues/2143 it should now be possible to remove the default disable of typechecking for near-operation-file preset.

Typechecking is important and should be enabled by default.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related https://github.com/dotansimha/graphql-code-generator-community/issues/214

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update ?

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

- Using the repository shared in the issue https://github.com/klyve/graphql-codegen-preset-test
- Upgrade to `"@graphql-codegen/near-operation-file-preset": "^2.5.0"` in `package.json` file and run `yarn`
- Updated the `node_modules/@graphql-codegen/near-operation-file-preset/cjs/index.js` with the changes in this PR
- `yarn test` and see the expected validation errors in the terminal.

| Before | After |
| ----- | ----- |
| <img width="1792" alt="image" src="https://github.com/dotansimha/graphql-code-generator-community/assets/1213542/cc484d63-b23b-4477-8e28-b6bd6dc86dc4"> | <img width="1792" alt="image" src="https://github.com/dotansimha/graphql-code-generator-community/assets/1213542/61a711bc-41f4-46df-a08e-8435b1352e42"> |

**Test Environment**:

- OS: macOS Ventura 13.4
- `@graphql-codegen/near-operation-file-preset`: 2.5.0 + changes
- NodeJS: v16.20.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ x I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I went with a solution closer to the suggested one in [this comment](https://github.com/dotansimha/graphql-code-generator/pull/8222#discussion_r950034010) in the original PR.

I think passing `undefined` should result on the default `{ skipDuplicateValidation : true }` but going with `false` should use that value but this could be an overkill, please share your thoughts on this..
