### PR TITLE
chore: correct default value in `legacyMode` docs comment

### DIFF
--- a/.changeset/shiny-trainers-exercise.md
+++ b/.changeset/shiny-trainers-exercise.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Correct default value in legacyMode docs comment

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -109,8 +109,8 @@ export interface ReactQueryRawPluginConfig
   addInfiniteQuery?: boolean;
 
   /**
-   * @default true
-   * @description If false, it will work with `@tanstack/react-query`, default value is true.
+   * @default false
+   * @description If false, it will work with `@tanstack/react-query`, default value is false.
    */
   legacyMode?: boolean;
 }

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -110,7 +110,7 @@ export interface ReactQueryRawPluginConfig
 
   /**
    * @default false
-   * @description If false, it will work with `@tanstack/react-query`, default value is false.
+   * @description If true, it imports `react-query` not `@tanstack/react-query`, default is false.
    */
   legacyMode?: boolean;
 }


### PR DESCRIPTION
## Description

Corrects the comment documenting the react-query `legacyMode` option to reflect the actual behaviour:

 - Corrects the default from `true` to `false` (the option actually defaults to false)
 - Tweak wording of comment to better reflect the effect of changing the value from its default

Related #390

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Checked the code to see how the config value is imported ([it's `false` by default](https://github.com/dotansimha/graphql-code-generator-community/blob/b2ab7cbf092843c1e10d541804e4fe2a94872525/packages/plugins/typescript/react-query/src/visitor.ts#L91))
- [x] Ran codegen locally with value unset, explicitly false, and explicitly true (unset matched explicit false)

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/typescript-react-query@4.1.0` 
- NodeJS: 18.16.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - **this is the only documentation I can find**
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - **N/A**, docs fix
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules