### PR TITLE
feat(typescript-graphql-request): add support for web-scoket client

### DIFF
--- a/packages/plugins/typescript/graphql-request/src/config.ts
+++ b/packages/plugins/typescript/graphql-request/src/config.ts
@@ -53,4 +53,29 @@ export interface RawGraphQLRequestPluginConfig extends RawClientSideBasePluginCo
    * ```
    */
   extensionsType?: string;
+
+  /**
+   * @description Set to true if you want to use web-socket client
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts"
+   *  import type { CodegenConfig } from '@graphql-codegen/cli';
+   *
+   *  const config: CodegenConfig = {
+   *    // ...
+   *    generates: {
+   *      'path/to/file.ts': {
+   *        plugins: ['typescript', 'typescript-operations', 'typescript-graphql-request'],
+   *        config: {
+   *          rawRequest: true,
+   *          useWebSocketClient: true
+   *        },
+   *      },
+   *    },
+   *  };
+   *  export default config;
+   * ```
+   */
+  useWebSocketClient?: boolean;
 }

--- a/packages/plugins/typescript/graphql-request/src/visitor.ts
+++ b/packages/plugins/typescript/graphql-request/src/visitor.ts
@@ -175,7 +175,7 @@ export class GraphQLRequestVisitor extends ClientSideBaseVisitor<
 
 const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
 ${extraVariables.join('\n')}
-export function getSdk(client:  ${
+export function getSdk(client: ${
       this.config.useWebSocketClient ? 'GraphQLWebSocketClient' : 'GraphQLClient'
     }, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {


### PR DESCRIPTION

## Description

This PR adds typescript code generation for [graphql-request](https://github.com/jasonkuhrt/graphql-request)'s GraphQLWebSocketClient

Related #401 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I ran the `yarn test` command in the root of the `graphql-code-generator-comminuty` project to check that the functionality is not broken and everything works as expected.

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/typescript-graphql-request`: 6.0.0
- NodeJS: 18.17.1

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
