### PR TITLE
Make offlineExchange import respect useTypeImports

### DIFF
--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -1,11 +1,11 @@
 import { IntrospectionQuery } from 'graphql';
 import gql from 'graphql-tag';
 import * as Urql from 'urql';
-import { offlineExchange } from '@urql/exchange-graphcache';
 import {
   OptimisticMutationResolver as GraphCacheOptimisticMutationResolver,
   Resolver as GraphCacheResolver,
   UpdateResolver as GraphCacheUpdateResolver,
+  offlineExchange,
 } from '@urql/exchange-graphcache';
 
 export type Maybe<T> = T | null;

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -276,12 +276,9 @@ function getOptimisticUpdatersConfig(
 }
 
 function getImports(config: UrqlGraphCacheConfig): string {
-  return [
-    "import { offlineExchange } from '@urql/exchange-graphcache';",
-    `${
+  return `${
       config.useTypeImports ? 'import type' : 'import'
-    } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';\n`,
-  ].join('\n');
+    } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, offlineExchange } from '@urql/exchange-graphcache';\n`;
 }
 
 export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOutput> = (

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -277,8 +277,8 @@ function getOptimisticUpdatersConfig(
 
 function getImports(config: UrqlGraphCacheConfig): string {
   return `${
-      config.useTypeImports ? 'import type' : 'import'
-    } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, offlineExchange } from '@urql/exchange-graphcache';\n`;
+    config.useTypeImports ? 'import type' : 'import'
+  } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, offlineExchange } from '@urql/exchange-graphcache';\n`;
 }
 
 export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOutput> = (

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`urql graphcache Should correctly name GraphCacheResolvers & GraphCacheOptimisticUpdaters with nonstandard mutationType names 1`] = `
-"import { offlineExchange } from '@urql/exchange-graphcache';
-import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
-
+import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, offlineExchange } from '@urql/exchange-graphcache';
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
 
 export type GraphCacheKeysConfig = {

--- a/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
@@ -166,8 +166,7 @@ describe('urql graphcache', () => {
     const result = mergeOutputs([await plugin(schema, [], { useTypeImports: true })]);
 
     expect(result).toBeSimilarStringTo(`\
-import { offlineExchange } from '@urql/exchange-graphcache';
-import type { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
+import type { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver, offlineExchange } from '@urql/exchange-graphcache';
 `);
   });
 


### PR DESCRIPTION
## Description

Change import of offlineExchange from `@urql/exchange-graphcache` to respect `config.useTypeImports` since only types are used in the generated code.

Related # (issue)

#445 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Have tested that typescript configured with importsNotUsedAsValues = `error` no longer throws errors during `tsc` after the change has been made. 


## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
