### PR TITLE
Allows versions 6.x of graphql-request to be used.

### DIFF
--- a/.changeset/nervous-apricots-dream.md
+++ b/.changeset/nervous-apricots-dream.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-rtk-query": minor
+---
+
+Allows versions `6.x` of `graphql-request` 

--- a/packages/plugins/typescript/rtk-query/package.json
+++ b/packages/plugins/typescript/rtk-query/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@reduxjs/toolkit": "^1.6.0",
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-request": "^3.4.0 || ^4.0.0 || ^5.0.0",
+    "graphql-request": "^3.4.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "graphql-tag": "^2.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Description

Allows graphql-request v6 to be used in conjunction with the rtk-query generator.

Related #448

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

https://codesandbox.io/p/sandbox/thirsty-wu-kym2hd

## How Has This Been Tested?

- [x] Ran unit tests
- [x] Tested locally with my application

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/...`: See [package.json](https://codesandbox.io/p/sandbox/thirsty-wu-kym2hd?file=%2Fpackage.json%3A9%2C3-16%2C5)
- NodeJS: 16

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
