### PR TITLE
feat(hasura-allow-list):add config to change fragments definition order

### DIFF
--- a/.changeset/long-zebras-perform.md
+++ b/.changeset/long-zebras-perform.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/hasura-allow-list": minor
+---
+
+add config to change fragments definition order

--- a/packages/plugins/other/hasura-allow-list/src/config.ts
+++ b/packages/plugins/other/hasura-allow-list/src/config.ts
@@ -16,4 +16,9 @@ export interface HasuraAllowListPluginConfig {
    * @description Whether to source fragments per-document, or globally. If set, will enforce fragment name uniqueness
    */
   globalFragments?: boolean;
+  /**
+   * @default definition
+   * @description Whether to order fragments by global definition order, or by definition order in the document
+   */
+  fragmentsOrder?: 'global' | 'document';
 }

--- a/packages/plugins/other/hasura-allow-list/tests/hasura-allow-list.spec.ts
+++ b/packages/plugins/other/hasura-allow-list/tests/hasura-allow-list.spec.ts
@@ -349,6 +349,50 @@ describe('Hasura allow list', () => {
 
     expect(content).toBe(expectedContent);
   });
+  it('with globalFragments enabled and fragmentsOrder set to document, should define fragment by the order they are defined in the document.', async () => {
+    const expectedContent = `- name: allowed-queries
+  definition:
+    queries:
+      - name: MyQuery1
+        query: |-
+          query MyQuery1 {
+            field
+            ...MyOtherFragment
+            ...MyFragment
+          }
+          fragment MyOtherFragment on Query {
+            field
+          }
+          fragment MyFragment on Query {
+            field
+          }
+`;
+    const document1 = parse(/* GraphQL */ `
+      query MyQuery1 {
+        field
+        ...MyOtherFragment
+        ...MyFragment
+      }
+      fragment MyFragment on Query {
+        field
+      }
+    `);
+    const document2 = parse(/* GraphQL */ `
+      fragment MyOtherFragment on Query {
+        field
+      }
+    `);
+    const content = await plugin(
+      null,
+      [
+        { document: document1, location: '/dummy/location1' },
+        { document: document2, location: '/dummy/location2' },
+      ],
+      { globalFragments: true, fragmentsOrder: 'document' },
+    );
+
+    expect(content).toBe(expectedContent);
+  });
   it('with globalFragments enabled, should error on missing fragments', async () => {
     const document1 = parse(/* GraphQL */ `
       query MyQuery1 {


### PR DESCRIPTION
## Description

add config to change fragments definition order.
Related #441 


## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I tested by new test code, and it generates allow list that define fragments in order they appear in the document when fragmentsOrder is set to document, and this allow list is compatible with some other plugins that did not work before. Default setting is global, and this works the same as before. So this is not breaking change.

**Test Environment**:

- OS:macOS Ventura v13.4
- NodeJS:v19.9.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

