### PR TITLE
Removes the unused generic when `rawRequest` is set to false #453

### DIFF
--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -142,8 +142,18 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<
       usingObservable ? 'Observable' : 'AsyncIterable'
     }<${resultData}>`;
 
-    return `export type Requester<C = {}, E = unknown> = <R, V>(doc: ${documentNodeType}, vars?: V, options?: C) => ${returnType}
+    if (this.config.rawRequest) {
+      return `export type Requester<C = {}, E = unknown> = <R, V>(doc: ${documentNodeType}, vars?: V, options?: C) => ${returnType}
 export function getSdk<C, E>(requester: Requester<C, E>) {
+  return {
+    ${allPossibleActions.join(',\n')}
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;`
+    }
+    
+    return `export type Requester<C = {}> = <R, V>(doc: ${documentNodeType}, vars?: V, options?: C) => ${returnType}
+export function getSdk<C>(requester: Requester<C>) {
   return {
 ${allPossibleActions.join(',\n')}
   };


### PR DESCRIPTION
Removes the unused generic when `rawRequest` is set to false

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

See  #453 

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This change fixes my local linting for the test project. I cannot forsee whether there will be more implications upstream though.

**Test Environment**:

 See #453 