### PR TITLE
fix(typescript-react-apollo): loosen defaultBaseOptions type

### DIFF
--- a/.changeset/happy-keys-kiss.md
+++ b/.changeset/happy-keys-kiss.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+fix: loosen defaultBaseOptions type

--- a/packages/plugins/typescript/react-apollo/src/config.ts
+++ b/packages/plugins/typescript/react-apollo/src/config.ts
@@ -242,7 +242,7 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    */
   addDocBlocks?: boolean;
 
-  defaultBaseOptions?: { [key: string]: string };
+  defaultBaseOptions?: { [key: string]: any };
 
   hooksSuffix?: string;
 }

--- a/packages/plugins/typescript/react-apollo/src/config.ts
+++ b/packages/plugins/typescript/react-apollo/src/config.ts
@@ -241,8 +241,21 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    * ```
    */
   addDocBlocks?: boolean;
-
-  defaultBaseOptions?: { [key: string]: any };
+  /**
+   * @description Configure default mutation and query hook options.
+   */
+  defaultBaseOptions?: ReactApolloPluginConfigDefaultBaseOptions;
 
   hooksSuffix?: string;
+}
+
+export interface ReactApolloPluginConfigDefaultBaseOptions {
+  awaitRefetchQueries?: boolean;
+  errorPolicy?: string;
+  fetchPolicy?: string;
+  ignoreResults?: boolean;
+  notifyOnNetworkStatusChange?: boolean;
+  returnPartialData?: boolean;
+  ssr?: boolean;
+  [key: string]: any;
 }

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -30,7 +30,7 @@ export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
   withResultType: boolean;
   withMutationOptionsType: boolean;
   addDocBlocks: boolean;
-  defaultBaseOptions: { [key: string]: string };
+  defaultBaseOptions: { [key: string]: any };
   hooksSuffix: string;
 }
 

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -10,7 +10,7 @@ import {
   LoadedFragment,
   OMIT_TYPE,
 } from '@graphql-codegen/visitor-plugin-common';
-import { ReactApolloRawPluginConfig } from './config.js';
+import { ReactApolloPluginConfigDefaultBaseOptions, ReactApolloRawPluginConfig } from './config.js';
 
 const APOLLO_CLIENT_3_UNIFIED_PACKAGE = `@apollo/client`;
 const GROUPED_APOLLO_CLIENT_3_IDENTIFIER = 'Apollo';
@@ -30,7 +30,7 @@ export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
   withResultType: boolean;
   withMutationOptionsType: boolean;
   addDocBlocks: boolean;
-  defaultBaseOptions: { [key: string]: any };
+  defaultBaseOptions: ReactApolloPluginConfigDefaultBaseOptions;
   hooksSuffix: string;
 }
 


### PR DESCRIPTION
## Description

TypeScript React Apollo's `defaultBaseOptions` object values are currently restricted to `string`:

https://github.com/dotansimha/graphql-code-generator-community/blob/0fea1a83eaf42f56ea68ed5f763fe00f2df7417a/packages/plugins/typescript/react-apollo/src/config.ts#L245

but they can be any number of data types, i.e. [`ignoreResults`](https://www.apollographql.com/docs/react/data/mutations#ignoreresults) is a `boolean`.

This loosens the type from `string` ➡️ `any`.

Related #463

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. configure an option with a non-string data type, i.e. [`ignoreResults`](https://www.apollographql.com/docs/react/data/mutations#ignoreresults):

    ```ts
    const config = {
        // ...
        defaultBaseOptions: {
            ignoreResults: true,
        }
    }
    ```

1. see that this passes TypeScript compilation

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
