### PR TITLE
fix: Support useTypeImports config inside msw

### DIFF
--- a/.changeset/tender-dryers-accept.md
+++ b/.changeset/tender-dryers-accept.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-msw': patch
+---
+
+Fix useTypeImports support

--- a/packages/plugins/typescript/msw/src/visitor.ts
+++ b/packages/plugins/typescript/msw/src/visitor.ts
@@ -44,7 +44,11 @@ export class MSWVisitor extends ClientSideBaseVisitor<MSWRawPluginConfig, MSWPlu
       return [];
     }
 
-    return [`import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'`];
+    return [
+      this.config.useTypeImports
+        ? `import { graphql, type ResponseResolver, GraphQLRequest, type GraphQLContext } from 'msw'`
+        : `import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'`,
+    ];
   }
 
   public getContent() {

--- a/packages/plugins/typescript/msw/tests/msw.spec.ts
+++ b/packages/plugins/typescript/msw/tests/msw.spec.ts
@@ -101,4 +101,11 @@ describe('msw', () => {
       'content with types configured via importOperationTypesFrom',
     );
   });
+
+  it('Should use the "useTypeImports" setting', async () => {
+    const resultWithTypeImports = await plugin(null, documents, { useTypeImports: true });
+    expect(resultWithTypeImports.prepend[0]).toContain(`type`);
+    const resultWithoutTypeImports = await plugin(null, documents, { useTypeImports: false });
+    expect(resultWithoutTypeImports.prepend[0]).not.toContain(`type`);
+  });
 });


### PR DESCRIPTION
## Description

This PR adds the `useTypeImports` config to @graphql-codegen/typescript-msw. Before this option had been ignored.


https://github.com/search?q=repo%3Adotansimha%2Fgraphql-code-generator-community+useTypeImports&type=issues

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Updated the unit tests

**Test Environment**:

- OS: MacOS
- `@graphql-codegen/typescript-msw`:
- NodeJS: `v18.18.0` `v20....`

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
