### PR TITLE
feat(graphcache): make offline exchange optional

### DIFF
--- a/.changeset/fresh-cooks-learn.md
+++ b/.changeset/fresh-cooks-learn.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/typescript-urql-graphcache': minor
+---
+
+Add setting to choose for the offlineExchange, otherwise this bugs out the types for folks not using
+the offlineExchange

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -1,7 +1,7 @@
 import { IntrospectionQuery } from 'graphql';
 import gql from 'graphql-tag';
 import * as Urql from 'urql';
-import { offlineExchange } from '@urql/exchange-graphcache';
+import { cacheExchange } from '@urql/exchange-graphcache';
 import {
   OptimisticMutationResolver as GraphCacheOptimisticMutationResolver,
   Resolver as GraphCacheResolver,
@@ -1293,7 +1293,7 @@ export type GraphCacheUpdaters = {
   };
 };
 
-export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
+export type GraphCacheConfig = Parameters<typeof cacheExchange>[0] & {
   updates?: GraphCacheUpdaters;
   keys?: GraphCacheKeysConfig;
   optimistic?: GraphCacheOptimisticUpdaters;

--- a/packages/plugins/typescript/urql-graphcache/src/config.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/config.ts
@@ -3,4 +3,6 @@ import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-c
 /**
  * @description This plugin generates a generic for the `@urql/exchange-graphcache` (https://github.com/FormidableLabs/urql/exchanges/graphcache) config.
  */
-export type UrqlGraphCacheConfig = RawClientSideBasePluginConfig & {};
+export type UrqlGraphCacheConfig = RawClientSideBasePluginConfig & {
+  offlineExchange: boolean;
+};

--- a/packages/plugins/typescript/urql-graphcache/src/config.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/config.ts
@@ -4,5 +4,5 @@ import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-c
  * @description This plugin generates a generic for the `@urql/exchange-graphcache` (https://github.com/FormidableLabs/urql/exchanges/graphcache) config.
  */
 export type UrqlGraphCacheConfig = RawClientSideBasePluginConfig & {
-  offlineExchange: boolean;
+  offlineExchange?: boolean;
 };

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -327,7 +327,9 @@ export const plugin: PluginFunction<UrqlGraphCacheConfig, Types.ComplexPluginOut
         `${typeUpdateResolvers.join(',\n')}` +
         ',\n};',
 
-      'export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {\n' +
+      `export type GraphCacheConfig = Parameters<typeof ${
+        config.offlineExchange ? 'offlineExchange' : 'cacheExchange'
+      }>[0] & {\n` +
         '  updates?: GraphCacheUpdaters,\n' +
         '  keys?: GraphCacheKeysConfig,\n' +
         '  optimistic?: GraphCacheOptimisticUpdaters,\n' +

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -277,7 +277,9 @@ function getOptimisticUpdatersConfig(
 
 function getImports(config: UrqlGraphCacheConfig): string {
   return [
-    "import { offlineExchange } from '@urql/exchange-graphcache';",
+    `import { ${
+      config.offlineExchange ? 'offlineExchange' : 'cacheExchange'
+    } } from '@urql/exchange-graphcache';`,
     `${
       config.useTypeImports ? 'import type' : 'import'
     } { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';\n`,

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -40,7 +40,7 @@ export type GraphCacheUpdaters = {
   },
 };
 
-export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
+export type GraphCacheConfig = Parameters<typeof cacheExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
@@ -84,7 +84,7 @@ export type GraphCacheUpdaters = {
   },
 };
 
-export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
+export type GraphCacheConfig = Parameters<typeof cacheExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
@@ -156,7 +156,7 @@ export type GraphCacheUpdaters = {
   },
 };
 
-export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
+export type GraphCacheConfig = Parameters<typeof cacheExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
@@ -227,7 +227,7 @@ export type GraphCacheUpdaters = {
   },
 };
 
-export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
+export type GraphCacheConfig = Parameters<typeof cacheExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
@@ -286,7 +286,7 @@ export type GraphCacheUpdaters = {
   },
 };
 
-export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
+export type GraphCacheConfig = Parameters<typeof cacheExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,
@@ -357,7 +357,7 @@ export type GraphCacheUpdaters = {
   },
 };
 
-export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
+export type GraphCacheConfig = Parameters<typeof cacheExchange>[0] & {
   updates?: GraphCacheUpdaters,
   keys?: GraphCacheKeysConfig,
   optimistic?: GraphCacheOptimisticUpdaters,

--- a/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/urql-graphcache/tests/__snapshots__/urql.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`urql graphcache Should correctly name GraphCacheResolvers & GraphCacheOptimisticUpdaters with nonstandard mutationType names 1`] = `
-"import { offlineExchange } from '@urql/exchange-graphcache';
+"import { cacheExchange } from '@urql/exchange-graphcache';
 import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
@@ -49,7 +49,7 @@ export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
 `;
 
 exports[`urql graphcache Should correctly output GraphCacheOptimisticUpdaters when there are no mutations 1`] = `
-"import { offlineExchange } from '@urql/exchange-graphcache';
+"import { cacheExchange } from '@urql/exchange-graphcache';
 import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
@@ -93,7 +93,7 @@ export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly (with interfaces) 1`] = `
-"import { offlineExchange } from '@urql/exchange-graphcache';
+"import { cacheExchange } from '@urql/exchange-graphcache';
 import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
@@ -165,7 +165,7 @@ export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly (with typesPrefix and typesSuffix) 1`] = `
-"import { offlineExchange } from '@urql/exchange-graphcache';
+"import { cacheExchange } from '@urql/exchange-graphcache';
 import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
@@ -236,7 +236,7 @@ export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly (with unions) 1`] = `
-"import { offlineExchange } from '@urql/exchange-graphcache';
+"import { cacheExchange } from '@urql/exchange-graphcache';
 import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };
@@ -295,7 +295,7 @@ export type GraphCacheConfig = Parameters<typeof offlineExchange>[0] & {
 `;
 
 exports[`urql graphcache Should output the cache-generic correctly 1`] = `
-"import { offlineExchange } from '@urql/exchange-graphcache';
+"import { cacheExchange } from '@urql/exchange-graphcache';
 import { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 
 export type WithTypename<T extends { __typename?: any }> = Partial<T> & { __typename: NonNullable<T['__typename']> };

--- a/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
+++ b/packages/plugins/typescript/urql-graphcache/tests/urql.spec.ts
@@ -166,7 +166,7 @@ describe('urql graphcache', () => {
     const result = mergeOutputs([await plugin(schema, [], { useTypeImports: true })]);
 
     expect(result).toBeSimilarStringTo(`\
-import { offlineExchange } from '@urql/exchange-graphcache';
+import { cacheExchange } from '@urql/exchange-graphcache';
 import type { Resolver as GraphCacheResolver, UpdateResolver as GraphCacheUpdateResolver, OptimisticMutationResolver as GraphCacheOptimisticMutationResolver } from '@urql/exchange-graphcache';
 `);
   });


### PR DESCRIPTION
## Description

In graphcache we export a cache and offline exchange, the offline exchange however needs extra settings like `storage` if this is unused then it's a bit hard for our implementor to use `cacheExchange` hence I propose adding an option for which export to use.

> this could be considered a breaking change, can also invert the option if you like

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
