### PR TITLE
feat(typescript-react-apollo): Apollo Client `useFragment` hook

### DIFF
--- a/.changeset/loud-monkeys-yawn.md
+++ b/.changeset/loud-monkeys-yawn.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-react-apollo": minor
+---
+
+Apollo Client `useFragment` hook

--- a/dev-test/codegen.ts
+++ b/dev-test/codegen.ts
@@ -44,7 +44,15 @@ const config: CodegenConfig = {
     './dev-test/githunt/types.reactApollo.hooks.tsx': {
       schema: './dev-test/githunt/schema.json',
       documents: './dev-test/githunt/**/*.graphql',
-      plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+      plugins: [
+        'typescript',
+        'typescript-operations',
+        {
+          'typescript-react-apollo': {
+            withFragmentHooks: true,
+          },
+        },
+      ],
     },
     './dev-test/githunt/types.react-query.ts': {
       schema: './dev-test/githunt/schema.json',

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -389,6 +389,52 @@ export const FeedEntryFragmentDoc = gql`
   ${VoteButtonsFragmentDoc}
   ${RepoInfoFragmentDoc}
 `;
+export function useCommentsPageCommentFragment(id: string) {
+  return Apollo.useFragment<CommentsPageCommentFragment>({
+    fragment: CommentsPageCommentFragmentDoc,
+    fragmentName: 'CommentsPageComment',
+    from: {
+      __typename: 'Comment',
+      id,
+    },
+  });
+}
+export type CommentsPageCommentFragmentHookResult = ReturnType<
+  typeof useCommentsPageCommentFragment
+>;
+export function useFeedEntryFragment(id: string) {
+  return Apollo.useFragment<FeedEntryFragment>({
+    fragment: FeedEntryFragmentDoc,
+    fragmentName: 'FeedEntry',
+    from: {
+      __typename: 'Entry',
+      id,
+    },
+  });
+}
+export type FeedEntryFragmentHookResult = ReturnType<typeof useFeedEntryFragment>;
+export function useRepoInfoFragment(id: string) {
+  return Apollo.useFragment<RepoInfoFragment>({
+    fragment: RepoInfoFragmentDoc,
+    fragmentName: 'RepoInfo',
+    from: {
+      __typename: 'Entry',
+      id,
+    },
+  });
+}
+export type RepoInfoFragmentHookResult = ReturnType<typeof useRepoInfoFragment>;
+export function useVoteButtonsFragment(id: string) {
+  return Apollo.useFragment<VoteButtonsFragment>({
+    fragment: VoteButtonsFragmentDoc,
+    fragmentName: 'VoteButtons',
+    from: {
+      __typename: 'Entry',
+      id,
+    },
+  });
+}
+export type VoteButtonsFragmentHookResult = ReturnType<typeof useVoteButtonsFragment>;
 export const OnCommentAddedDocument = gql`
   subscription onCommentAdded($repoFullName: String!) {
     commentAdded(repoFullName: $repoFullName) {

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -389,48 +389,48 @@ export const FeedEntryFragmentDoc = gql`
   ${VoteButtonsFragmentDoc}
   ${RepoInfoFragmentDoc}
 `;
-export function useCommentsPageCommentFragment(id: string) {
+export function useCommentsPageCommentFragment<F = { id: string }>(identifiers: F) {
   return Apollo.useFragment<CommentsPageCommentFragment>({
     fragment: CommentsPageCommentFragmentDoc,
     fragmentName: 'CommentsPageComment',
     from: {
       __typename: 'Comment',
-      id,
+      ...identifiers,
     },
   });
 }
 export type CommentsPageCommentFragmentHookResult = ReturnType<
   typeof useCommentsPageCommentFragment
 >;
-export function useFeedEntryFragment(id: string) {
+export function useFeedEntryFragment<F = { id: string }>(identifiers: F) {
   return Apollo.useFragment<FeedEntryFragment>({
     fragment: FeedEntryFragmentDoc,
     fragmentName: 'FeedEntry',
     from: {
       __typename: 'Entry',
-      id,
+      ...identifiers,
     },
   });
 }
 export type FeedEntryFragmentHookResult = ReturnType<typeof useFeedEntryFragment>;
-export function useRepoInfoFragment(id: string) {
+export function useRepoInfoFragment<F = { id: string }>(identifiers: F) {
   return Apollo.useFragment<RepoInfoFragment>({
     fragment: RepoInfoFragmentDoc,
     fragmentName: 'RepoInfo',
     from: {
       __typename: 'Entry',
-      id,
+      ...identifiers,
     },
   });
 }
 export type RepoInfoFragmentHookResult = ReturnType<typeof useRepoInfoFragment>;
-export function useVoteButtonsFragment(id: string) {
+export function useVoteButtonsFragment<F = { id: string }>(identifiers: F) {
   return Apollo.useFragment<VoteButtonsFragment>({
     fragment: VoteButtonsFragmentDoc,
     fragmentName: 'VoteButtons',
     from: {
       __typename: 'Entry',
-      id,
+      ...identifiers,
     },
   });
 }

--- a/packages/plugins/typescript/react-apollo/src/config.ts
+++ b/packages/plugins/typescript/react-apollo/src/config.ts
@@ -217,6 +217,31 @@ export interface ReactApolloRawPluginConfig extends RawClientSideBasePluginConfi
    * ```
    */
   withMutationOptionsType?: boolean;
+
+  /**
+   * @description Whether or not to include wrappers for Apollo's useFragment hook.
+   * @default false
+   *
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts"
+   *  import type { CodegenConfig } from '@graphql-codegen/cli';
+   *
+   *  const config: CodegenConfig = {
+   *    // ...
+   *    generates: {
+   *      'path/to/file.ts': {
+   *        plugins: ['typescript', 'typescript-operations', 'typescript-react-apollo'],
+   *        config: {
+   *          withFragmentHooks: true
+   *        },
+   *      },
+   *    },
+   *  };
+   *  export default config;
+   * ```
+   */
+  withFragmentHooks?: boolean;
+
   /**
    * @description Allows you to enable/disable the generation of docblocks in generated code.
    * Some IDE's (like VSCode) add extra inline information with docblocks, you can disable this feature if your preferred IDE does not.

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -623,13 +623,13 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<
 
       const IDType = this.scalars.ID ?? 'string';
 
-      const hook = `export function use${fragmentName}(id: ${IDType}) {
+      const hook = `export function use${fragmentName}<F = { id: ${IDType} }>(identifiers: F) {
   return ${this.getApolloReactHooksIdentifier()}.use${operationType}<${operationResultType}>({
     fragment: ${nodeName}${this.config.fragmentVariableSuffix},
     fragmentName: "${nodeName}",
     from: {
       __typename: "${fragment.onType}",
-      id,
+      ...identifiers,
     },
   });
 }`;

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -21,6 +21,7 @@ export interface ReactApolloPluginConfig extends ClientSideBasePluginConfig {
   withHooks: boolean;
   withMutationFn: boolean;
   withRefetchFn: boolean;
+  withFragmentHooks?: boolean;
   apolloReactCommonImportFrom: string;
   apolloReactComponentsImportFrom: string;
   apolloReactHocImportFrom: string;
@@ -62,6 +63,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<
       withHooks: getConfigValue(rawConfig.withHooks, true),
       withMutationFn: getConfigValue(rawConfig.withMutationFn, true),
       withRefetchFn: getConfigValue(rawConfig.withRefetchFn, false),
+      withFragmentHooks: getConfigValue(rawConfig.withFragmentHooks, false),
       apolloReactCommonImportFrom: getConfigValue(
         rawConfig.apolloReactCommonImportFrom,
         rawConfig.reactApolloVersion === 2
@@ -192,8 +194,12 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<
     const baseImports = super.getImports();
     const hasOperations = this._collectedOperations.length > 0;
 
-    if (!hasOperations) {
+    if (!hasOperations && !this.config.withFragmentHooks) {
       return baseImports;
+    }
+
+    if (this.config.withFragmentHooks) {
+      return [...baseImports, this.getApolloReactHooksImport(false), ...Array.from(this.imports)];
     }
 
     return [...baseImports, ...Array.from(this.imports)];
@@ -582,5 +588,59 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<
     return [mutationFn, component, hoc, hooks, resultType, mutationOptionsType, refetchFn]
       .filter(a => a)
       .join('\n');
+  }
+
+  public get fragments(): string {
+    const fragments = super.fragments;
+
+    if (this._fragments.length === 0 || !this.config.withFragmentHooks) {
+      return fragments;
+    }
+
+    const operationType = 'Fragment';
+
+    const hookFns: string[] = [fragments];
+
+    for (const fragment of this._fragments.values()) {
+      if (fragment.isExternal) {
+        continue;
+      }
+
+      const nodeName = fragment.name ?? '';
+      const suffix = this._getHookSuffix(nodeName, operationType);
+      const fragmentName: string =
+        this.convertName(nodeName, {
+          suffix,
+          useTypesPrefix: false,
+          useTypesSuffix: false,
+        }) + this.config.hooksSuffix;
+
+      const operationTypeSuffix: string = this.getOperationSuffix(fragmentName, operationType);
+
+      const operationResultType: string = this.convertName(nodeName, {
+        suffix: operationTypeSuffix + this._parsedConfig.operationResultSuffix,
+      });
+
+      const IDType = this.scalars.ID ?? 'string';
+
+      const hook = `export function use${fragmentName}(id: ${IDType}) {
+  return ${this.getApolloReactHooksIdentifier()}.use${operationType}<${operationResultType}>({
+    fragment: ${nodeName}${this.config.fragmentVariableSuffix},
+    fragmentName: "${nodeName}",
+    from: {
+      __typename: "${fragment.onType}",
+      id,
+    },
+  });
+}`;
+
+      const hookResults = [
+        `export type ${fragmentName}HookResult = ReturnType<typeof use${fragmentName}>;`,
+      ];
+
+      hookFns.push([hook, hookResults].join('\n'));
+    }
+
+    return hookFns.join('\n');
   }
 }

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -70,6 +70,16 @@ describe('React Apollo', () => {
     }
   `);
 
+  const fragmentDoc = parse(/* GraphQL */ `
+    fragment RepositoryFields on Repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  `);
+
   const validateTypeScript = async (
     output: Types.PluginOutput,
     testSchema: GraphQLSchema,
@@ -2722,6 +2732,40 @@ export function useListenToCommentsSubscription(baseOptions?: Apollo.Subscriptio
       export const TestComponent = (props: TestComponentProps) => (
         <ApolloReactComponents.Mutation<TestMutation, TestMutationVariables> mutation={Operations.test} {...props} />
       );`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
+    it('should import fragments from near operation file for useFragment', async () => {
+      const config: ReactApolloRawPluginConfig = {
+        documentMode: DocumentMode.external,
+        importDocumentNodeExternallyFrom: 'near-operation-file',
+        withComponent: false,
+        withHooks: true,
+        withHOC: false,
+        withFragmentHooks: true,
+      };
+
+      const docs = [{ location: 'path/to/document.graphql', document: fragmentDoc }];
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.tsx',
+      })) as Types.ComplexPluginOutput;
+
+      expect(content.prepend[0]).toBeSimilarStringTo(`import * as Apollo from '@apollo/client';`);
+
+      expect(content.content).toBeSimilarStringTo(`
+      export function useRepositoryFieldsFragment(id: string) {
+        return Apollo.useFragment<RepositoryFieldsFragment>({
+          fragment: RepositoryFieldsFragmentDoc,
+          fragmentName: "RepositoryFields",
+          from: {
+            __typename: "Repository",
+            id,
+          },
+        });
+      }
+      export type RepositoryFieldsFragmentHookResult = ReturnType<typeof useRepositoryFieldsFragment>;
+      `);
       await validateTypeScript(content, schema, docs, {});
     });
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -2754,13 +2754,13 @@ export function useListenToCommentsSubscription(baseOptions?: Apollo.Subscriptio
       expect(content.prepend[0]).toBeSimilarStringTo(`import * as Apollo from '@apollo/client';`);
 
       expect(content.content).toBeSimilarStringTo(`
-      export function useRepositoryFieldsFragment(id: string) {
+      export function useRepositoryFieldsFragment<F = { id: string }>(identifiers: F) {
         return Apollo.useFragment<RepositoryFieldsFragment>({
           fragment: RepositoryFieldsFragmentDoc,
           fragmentName: "RepositoryFields",
           from: {
             __typename: "Repository",
-            id,
+            ...identifiers,
           },
         });
       }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Related #482  

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] wrote a new test, updated a `dev-test` file, ran `yarn build`, `yarn generate:examples`, `yarn test` and all completed successfully
- [x] ran the updated code in my project at work and had `useFragment` hooks generated as expected

**Test Environment**:

- OS: macOS Sonoma 14.1
- `@graphql-codegen/typescript-react-apollo@4.1.0`:
- NodeJS: 20.9.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The solution(s) I came up with here may not be the most optimal, this is the first time I've looked through the code used for `graphql-codegen` so there could be better ways to do this
