### PR TITLE
typescript-msw: future proof types for generated mock functions

### DIFF
--- a/.changeset/tidy-trains-wait.md
+++ b/.changeset/tidy-trains-wait.md
@@ -2,4 +2,4 @@
 '@graphql-codegen/typescript-msw': patch
 ---
 
-future proof types for generated mock functions
+future proof types for generated mock functions - this also adds support for `msw@2`. 

--- a/.changeset/tidy-trains-wait.md
+++ b/.changeset/tidy-trains-wait.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/typescript-msw': patch
+'@graphql-codegen/typescript-msw': minor
 ---
 
 future proof types for generated mock functions - this also adds support for `msw@2`. 

--- a/.changeset/tidy-trains-wait.md
+++ b/.changeset/tidy-trains-wait.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-msw': patch
+---
+
+future proof types for generated mock functions

--- a/packages/plugins/typescript/msw/src/visitor.ts
+++ b/packages/plugins/typescript/msw/src/visitor.ts
@@ -81,8 +81,8 @@ export class MSWVisitor extends ClientSideBaseVisitor<MSWRawPluginConfig, MSWPlu
  * })
  */
 export const ${handlerName} = (resolver: Parameters<typeof ${
-  link?.name || 'graphql'
-}.${operationType.toLowerCase()}<${operationResultType}, ${operationVariablesTypes}>>[1]) =>
+            link?.name || 'graphql'
+          }.${operationType.toLowerCase()}<${operationResultType}, ${operationVariablesTypes}>>[1]) =>
   ${
     link?.name || 'graphql'
   }.${operationType.toLowerCase()}<${operationResultType}, ${operationVariablesTypes}>(

--- a/packages/plugins/typescript/msw/src/visitor.ts
+++ b/packages/plugins/typescript/msw/src/visitor.ts
@@ -44,7 +44,7 @@ export class MSWVisitor extends ClientSideBaseVisitor<MSWRawPluginConfig, MSWPlu
       return [];
     }
 
-    return [`import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'`];
+    return [`import { graphql } from 'msw'`];
   }
 
   public getContent() {
@@ -80,7 +80,7 @@ export class MSWVisitor extends ClientSideBaseVisitor<MSWRawPluginConfig, MSWPlu
  *   )
  * })
  */
-export const ${handlerName} = (resolver: ResponseResolver<GraphQLRequest<${operationVariablesTypes}>, GraphQLContext<${operationResultType}>, any>) =>
+export const ${handlerName} = (resolver: Parameters<typeof graphql.query<${operationResultType}, ${operationVariablesTypes}>>[1]) =>
   ${
     link?.name || 'graphql'
   }.${operationType.toLowerCase()}<${operationResultType}, ${operationVariablesTypes}>(

--- a/packages/plugins/typescript/msw/src/visitor.ts
+++ b/packages/plugins/typescript/msw/src/visitor.ts
@@ -80,7 +80,9 @@ export class MSWVisitor extends ClientSideBaseVisitor<MSWRawPluginConfig, MSWPlu
  *   )
  * })
  */
-export const ${handlerName} = (resolver: Parameters<typeof graphql.query<${operationResultType}, ${operationVariablesTypes}>>[1]) =>
+export const ${handlerName} = (resolver: Parameters<typeof ${
+  link?.name || 'graphql'
+}.${operationType.toLowerCase()}<${operationResultType}, ${operationVariablesTypes}>>[1]) =>
   ${
     link?.name || 'graphql'
   }.${operationType.toLowerCase()}<${operationResultType}, ${operationVariablesTypes}>(

--- a/packages/plugins/typescript/msw/tests/__snapshots__/msw.spec.ts.snap
+++ b/packages/plugins/typescript/msw/tests/__snapshots__/msw.spec.ts.snap
@@ -51,7 +51,7 @@ exports[`msw Should generate a link with an endpoint when passed a link variable
  *   )
  * })
  */
-export const mockUserQueryApi = (resolver: Parameters<typeof graphql.query<UserQuery, UserQueryVariables>>[1]) =>
+export const mockUserQueryApi = (resolver: Parameters<typeof api.query<UserQuery, UserQueryVariables>>[1]) =>
   api.query<UserQuery, UserQueryVariables>(
     'User',
     resolver
@@ -150,7 +150,7 @@ export const mockUpdateUserMutation = (resolver: Parameters<typeof graphql.mutat
 
 exports[`msw Should generate mocks based on queries and mutations: imports 1`] = `
 [
-  "import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'",
+  "import { graphql } from 'msw'",
 ]
 `;
 

--- a/packages/plugins/typescript/msw/tests/__snapshots__/msw.spec.ts.snap
+++ b/packages/plugins/typescript/msw/tests/__snapshots__/msw.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`msw Should generate JSDoc documentation with variables and selection fr
  *   )
  * })
  */
-export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<UserQueryVariables>, GraphQLContext<UserQuery>, any>) =>
+export const mockUserQuery = (resolver: Parameters<typeof graphql.query<UserQuery, UserQueryVariables>>[1]) =>
   graphql.query<UserQuery, UserQueryVariables>(
     'User',
     resolver
@@ -30,7 +30,7 @@ export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<UserQuer
  *   )
  * })
  */
-export const mockUpdateUserMutation = (resolver: ResponseResolver<GraphQLRequest<UpdateUserMutationVariables>, GraphQLContext<UpdateUserMutation>, any>) =>
+export const mockUpdateUserMutation = (resolver: Parameters<typeof graphql.mutation<UpdateUserMutation, UpdateUserMutationVariables>>[1]) =>
   graphql.mutation<UpdateUserMutation, UpdateUserMutationVariables>(
     'UpdateUser',
     resolver
@@ -51,7 +51,7 @@ exports[`msw Should generate a link with an endpoint when passed a link variable
  *   )
  * })
  */
-export const mockUserQueryApi = (resolver: ResponseResolver<GraphQLRequest<UserQueryVariables>, GraphQLContext<UserQuery>, any>) =>
+export const mockUserQueryApi = (resolver: Parameters<typeof graphql.query<UserQuery, UserQueryVariables>>[1]) =>
   api.query<UserQuery, UserQueryVariables>(
     'User',
     resolver
@@ -67,7 +67,7 @@ export const mockUserQueryApi = (resolver: ResponseResolver<GraphQLRequest<UserQ
  *   )
  * })
  */
-export const mockUpdateUserMutationApi = (resolver: ResponseResolver<GraphQLRequest<UpdateUserMutationVariables>, GraphQLContext<UpdateUserMutation>, any>) =>
+export const mockUpdateUserMutationApi = (resolver: Parameters<typeof api.mutation<UpdateUserMutation, UpdateUserMutationVariables>>[1]) =>
   api.mutation<UpdateUserMutation, UpdateUserMutationVariables>(
     'UpdateUser',
     resolver
@@ -88,7 +88,7 @@ exports[`msw Should generate handlerNames without suffix when withSuffix is fals
  *   )
  * })
  */
-export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<UserQueryVariables>, GraphQLContext<UserQuery>, any>) =>
+export const mockUserQuery = (resolver: Parameters<typeof api.query<UserQuery, UserQueryVariables>>[1]) =>
   api.query<UserQuery, UserQueryVariables>(
     'User',
     resolver
@@ -104,7 +104,7 @@ export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<UserQuer
  *   )
  * })
  */
-export const mockUpdateUserMutation = (resolver: ResponseResolver<GraphQLRequest<UpdateUserMutationVariables>, GraphQLContext<UpdateUserMutation>, any>) =>
+export const mockUpdateUserMutation = (resolver: Parameters<typeof api.mutation<UpdateUserMutation, UpdateUserMutationVariables>>[1]) =>
   api.mutation<UpdateUserMutation, UpdateUserMutationVariables>(
     'UpdateUser',
     resolver
@@ -124,7 +124,7 @@ exports[`msw Should generate mocks based on queries and mutations: content 1`] =
  *   )
  * })
  */
-export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<UserQueryVariables>, GraphQLContext<UserQuery>, any>) =>
+export const mockUserQuery = (resolver: Parameters<typeof graphql.query<UserQuery, UserQueryVariables>>[1]) =>
   graphql.query<UserQuery, UserQueryVariables>(
     'User',
     resolver
@@ -140,7 +140,7 @@ export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<UserQuer
  *   )
  * })
  */
-export const mockUpdateUserMutation = (resolver: ResponseResolver<GraphQLRequest<UpdateUserMutationVariables>, GraphQLContext<UpdateUserMutation>, any>) =>
+export const mockUpdateUserMutation = (resolver: Parameters<typeof graphql.mutation<UpdateUserMutation, UpdateUserMutationVariables>>[1]) =>
   graphql.mutation<UpdateUserMutation, UpdateUserMutationVariables>(
     'UpdateUser',
     resolver
@@ -166,7 +166,7 @@ exports[`msw Should use the "importOperationTypesFrom" setting: content with typ
  *   )
  * })
  */
-export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<Types.UserQueryVariables>, GraphQLContext<Types.UserQuery>, any>) =>
+export const mockUserQuery = (resolver: Parameters<typeof graphql.query<Types.UserQuery, Types.UserQueryVariables>>[1]) =>
   graphql.query<Types.UserQuery, Types.UserQueryVariables>(
     'User',
     resolver
@@ -182,7 +182,7 @@ export const mockUserQuery = (resolver: ResponseResolver<GraphQLRequest<Types.Us
  *   )
  * })
  */
-export const mockUpdateUserMutation = (resolver: ResponseResolver<GraphQLRequest<Types.UpdateUserMutationVariables>, GraphQLContext<Types.UpdateUserMutation>, any>) =>
+export const mockUpdateUserMutation = (resolver: Parameters<typeof graphql.mutation<Types.UpdateUserMutation, Types.UpdateUserMutationVariables>>[1]) =>
   graphql.mutation<Types.UpdateUserMutation, Types.UpdateUserMutationVariables>(
     'UpdateUser',
     resolver

--- a/packages/plugins/typescript/msw/tests/msw.spec.ts
+++ b/packages/plugins/typescript/msw/tests/msw.spec.ts
@@ -87,14 +87,16 @@ describe('msw', () => {
     // handler variable and result type
     const queryVariablesType = `${importOperationTypesFrom}.${queryName}QueryVariables`;
     const queryType = `${importOperationTypesFrom}.${queryName}Query`;
-    expect(result.content).toContain(`GraphQLRequest<${queryVariablesType}>`);
-    expect(result.content).toContain(`GraphQLContext<${queryType}>`);
+    expect(result.content).toContain(
+      `Parameters<typeof graphql.query<${queryType}, ${queryVariablesType}>>[1]`,
+    );
     expect(result.content).toContain(`graphql.query<${queryType}, ${queryVariablesType}>`);
 
     const mutationVariablesType = `${importOperationTypesFrom}.${mutationName}MutationVariables`;
     const mutationType = `${importOperationTypesFrom}.${mutationName}Mutation`;
-    expect(result.content).toContain(`GraphQLRequest<${mutationVariablesType}>`);
-    expect(result.content).toContain(`GraphQLContext<${mutationType}>`);
+    expect(result.content).toContain(
+      `Parameters<typeof graphql.mutation<${mutationType}, ${mutationVariablesType}>>[1]`,
+    );
     expect(result.content).toContain(`graphql.mutation<${mutationType}, ${mutationVariablesType}>`);
 
     expect(result.content).toMatchSnapshot(


### PR DESCRIPTION
## Description

With the latest version of `msw`, the `typescript-msw` plugin generates code that doesn't compile. The generated code uses imports that are no longer available in `msw@2` (specifically `GraphQLRequest` and `GraphQLContext`).

This change makes the generated code more future proof, by typing the generated function with referencing the `typeof` for the `msw` graphql function instead of explicitly re-typing the expected `resolver`.

[See reproduction in CodeSandbox](https://codesandbox.io/p/sandbox/elastic-mclean-xn97t2?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522cloo2l8h600073b6iefn4iivp%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522cloo2l8h600033b6icziuqznq%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522cloo2l8h600053b6iffdeg0m4%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522cloo2l8h600063b6i71zurrki%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B100%252C0%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522cloo2l8h600033b6icziuqznq%2522%253A%257B%2522id%2522%253A%2522cloo2l8h600033b6icziuqznq%2522%252C%2522activeTabId%2522%253A%2522cloo2on4s00v13b6iq90rzlqq%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cloo2l8h600023b6i17s2r6wm%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fpackage.json%2522%252C%2522id%2522%253A%2522cloo2mjpz006v3b6iga92pyg9%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fcodegen.ts%2522%252C%2522id%2522%253A%2522cloo2n2xg00dx3b6illci808p%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Fcheck.tsx%2522%252C%2522id%2522%253A%2522cloo2nnrm00m03b6ifwwgobnv%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Fgql%252Fgraphql.ts%2522%252C%2522id%2522%253A%2522cloo2on4s00v13b6iq90rzlqq%2522%252C%2522mode%2522%253A%2522temporary%2522%257D%255D%257D%252C%2522cloo2l8h600063b6i71zurrki%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522cloo2l8h600063b6i71zurrki%2522%257D%252C%2522cloo2l8h600053b6iffdeg0m4%2522%253A%257B%2522id%2522%253A%2522cloo2l8h600053b6iffdeg0m4%2522%252C%2522activeTabId%2522%253A%2522cloo2lbnp004c3b6il702iyfe%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cloo2l8h600043b6ifjrx6k9h%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522start%2522%257D%252C%257B%2522id%2522%253A%2522cloo2lbnp004c3b6il702iyfe%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522cloo2lbxj00x0efg6b6th5c6o%2522%257D%255D%257D%257D%252C%2522showDevtools%2522%253Afalse%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Performed the change manually in the reproduction project.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules