### PR TITLE
Generate explicit type for variables used in a subscription to work with URQL v4

### DIFF
--- a/.changeset/kind-pens-argue.md
+++ b/.changeset/kind-pens-argue.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/typescript-vue-urql': minor
+---
+
+Generate explicit type for variables used in a subscription to work with urql v4
+Possibly a breaking change - now it requires to define empty object for variables argument if no variables are used in subscription

--- a/packages/plugins/typescript/vue-urql/src/visitor.ts
+++ b/packages/plugins/typescript/vue-urql/src/visitor.ts
@@ -92,7 +92,7 @@ export function use${operationName}() {
 
     if (operationType === 'Subscription') {
       return `
-export function use${operationName}<R = ${operationResultType}>(options: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes}>, 'query'> = {}, handler?: Urql.SubscriptionHandlerArg<${operationResultType}, R>) {
+export function use${operationName}<R = ${operationResultType}>(options: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes}>, 'query'>, handler?: Urql.SubscriptionHandlerArg<${operationResultType}, R>) {
   return Urql.use${operationType}<${operationResultType}, R, ${operationVariablesTypes}>({ query: ${documentVariableName}, ...options }, handler);
 };`;
     }

--- a/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
@@ -13,7 +13,7 @@ export const ListenToCommentsDocument = gql\`
 }
     \`;
 
-export function useListenToCommentsSubscription<R = ListenToCommentsSubscription>(options: Omit<Urql.UseSubscriptionArgs<never, ListenToCommentsSubscriptionVariables>, 'query'> = {}, handler?: Urql.SubscriptionHandlerArg<ListenToCommentsSubscription, R>) {
+export function useListenToCommentsSubscription<R = ListenToCommentsSubscription>(options: Omit<Urql.UseSubscriptionArgs<never, ListenToCommentsSubscriptionVariables>, 'query'>, handler?: Urql.SubscriptionHandlerArg<ListenToCommentsSubscription, R>) {
   return Urql.useSubscription<ListenToCommentsSubscription, R, ListenToCommentsSubscriptionVariables>({ query: ListenToCommentsDocument, ...options }, handler);
 };"
 `;

--- a/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
@@ -524,7 +524,7 @@ export function useSubmitRepositoryMutation() {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-      export function useListenToCommentsSubscription<R = ListenToCommentsSubscription>(options: Omit<Urql.UseSubscriptionArgs<never, ListenToCommentsSubscriptionVariables>, 'query'> = {}, handler?: Urql.SubscriptionHandlerArg<ListenToCommentsSubscription, R>) {
+      export function useListenToCommentsSubscription<R = ListenToCommentsSubscription>(options: Omit<Urql.UseSubscriptionArgs<never, ListenToCommentsSubscriptionVariables>, 'query'>, handler?: Urql.SubscriptionHandlerArg<ListenToCommentsSubscription, R>) {
         return Urql.useSubscription<ListenToCommentsSubscription, R, ListenToCommentsSubscriptionVariables>({ query: ListenToCommentsDocument, ...options }, handler);
       };`);
       await validateTypeScript(content, schema, docs, {});


### PR DESCRIPTION
## Description

Generate explicit type for variables used in a subscription to work with URQL v4

This is basically the same as accepted https://github.com/dotansimha/graphql-code-generator-community/pull/329#issue-1664396694 but for subscriptions.

Otherwise it doesn't compile generated files if subscription have a required variable.

**WARNING:** This is possibly a breaking change - now it requires to define empty object for variables argument if no variables are used in subscription

Related #328

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

**Test Environment**:

- OS: Linux
- `@graphql-codegen/typescript-vue-urql`:
- NodeJS: 18.14.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
