### PR TITLE
Add .mts and .cts as allowable extensions to graphql-request

### DIFF
--- a/.changeset/silent-brooms-fly.md
+++ b/.changeset/silent-brooms-fly.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-graphql-request": patch
+---
+
+Add `.mts` and `.cts` as allowable extensions to graphql-request

--- a/packages/plugins/typescript/graphql-request/src/index.ts
+++ b/packages/plugins/typescript/graphql-request/src/index.ts
@@ -46,8 +46,10 @@ export const validate: PluginValidateFn<any> = async (
   config: RawClientSideBasePluginConfig,
   outputFile: string,
 ) => {
-  if (![".ts", ".mts", ".cts"].includes(extname(outputFile))) {
-    throw new Error(`Plugin "typescript-graphql-request" requires extension to be ".ts", ".mts" or ".cts"!`);
+  if (!['.ts', '.mts', '.cts'].includes(extname(outputFile))) {
+    throw new Error(
+      `Plugin "typescript-graphql-request" requires extension to be ".ts", ".mts" or ".cts"!`,
+    );
   }
 };
 

--- a/packages/plugins/typescript/graphql-request/src/index.ts
+++ b/packages/plugins/typescript/graphql-request/src/index.ts
@@ -46,8 +46,8 @@ export const validate: PluginValidateFn<any> = async (
   config: RawClientSideBasePluginConfig,
   outputFile: string,
 ) => {
-  if (extname(outputFile) !== '.ts') {
-    throw new Error(`Plugin "typescript-graphql-request" requires extension to be ".ts"!`);
+  if (![".ts", ".mts", ".cts"].includes(extname(outputFile))) {
+    throw new Error(`Plugin "typescript-graphql-request" requires extension to be ".ts", ".mts" or ".cts"!`);
   }
 };
 


### PR DESCRIPTION
## Description

The `.ts` requirement seems like it's purely there to protect users. However, I'd like the file to be `.mts` so that it gets compiled into a `.mjs` file.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Applied similar patch via `patch-package`

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
