### PR TITLE
Feature/add nestjs support for type graphql plugin

### DIFF
--- a/packages/plugins/typescript/type-graphql/src/config.ts
+++ b/packages/plugins/typescript/type-graphql/src/config.ts
@@ -31,4 +31,28 @@ export interface TypeGraphQLPluginConfig extends TypeScriptPluginConfig {
    * ```
    */
   decorateTypes?: string[];
+
+  /**
+   * @name useNestJSGraphQL
+   * @description Use @nestjs/graphql instead of type-graphql
+   * @default false
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts"
+   * import type { CodegenConfig } from '@graphql-codegen/cli';
+   *  const config: CodegenConfig = {
+   *   // ...
+   *  generates: {
+   *   'path/to/file.ts': {
+   *    plugins: [ 'typescript-type-graphql' ],
+   *   config: {
+   *   useNestJSGraphQL: true,
+   *  },
+   * },
+   * },
+   * };
+   * export default config;
+   * ```
+   */
+
+  useNestJSGraphQL?: boolean;
 }

--- a/packages/plugins/typescript/type-graphql/src/index.ts
+++ b/packages/plugins/typescript/type-graphql/src/index.ts
@@ -15,8 +15,15 @@ import { TypeGraphQLVisitor } from './visitor.js';
 export * from './visitor.js';
 
 const TYPE_GRAPHQL_IMPORT = `import * as TypeGraphQL from 'type-graphql';\nexport { TypeGraphQL };`;
-const isDefinitionInterface = (definition: string) =>
-  definition.includes('@TypeGraphQL.InterfaceType()');
+const NESTJS_GRAPHQL_IMPORT = `import * as NestJSGraphQL from '@nestjs/graphql';\nexport { NestJSGraphQL };`;
+
+const isDefinitionInterface = (
+  definition: string,
+  { useNestJSGraphQL }: TypeGraphQLPluginConfig = {},
+) =>
+  useNestJSGraphQL
+    ? definition.includes('@NestJSGraphQL.InterfaceType()')
+    : definition.includes('@TypeGraphQL.InterfaceType()');
 
 export const plugin: PluginFunction<TypeGraphQLPluginConfig, Types.ComplexPluginOutput> = (
   schema: GraphQLSchema,
@@ -40,7 +47,7 @@ export const plugin: PluginFunction<TypeGraphQLPluginConfig, Types.ComplexPlugin
     prepend: [
       ...visitor.getEnumsImports(),
       ...visitor.getWrapperDefinitions(),
-      TYPE_GRAPHQL_IMPORT,
+      config.useNestJSGraphQL ? NESTJS_GRAPHQL_IMPORT : TYPE_GRAPHQL_IMPORT,
     ],
     content: [scalars, ...definitions, ...introspectionDefinitions].join('\n'),
   };

--- a/packages/plugins/typescript/type-graphql/src/visitor.ts
+++ b/packages/plugins/typescript/type-graphql/src/visitor.ts
@@ -39,6 +39,7 @@ export interface TypeGraphQLPluginParsedConfig extends TypeScriptPluginParsedCon
   maybeValue: string;
   decoratorName: DecoratorConfig;
   decorateTypes?: string[];
+  useNestJSGraphQL?: boolean;
 }
 
 const MAYBE_REGEX = /^Maybe<(.*?)>$/;
@@ -46,7 +47,7 @@ const ARRAY_REGEX = /^Array<(.*?)>$/;
 const SCALAR_REGEX = /^Scalars\['(.*?)'\]$/;
 const GRAPHQL_TYPES = ['Query', 'Mutation', 'Subscription'];
 const SCALARS = ['ID', 'String', 'Boolean', 'Int', 'Float'];
-const TYPE_GRAPHQL_SCALARS = ['ID', 'Int', 'Float'];
+const GRAPHQL_SCALARS = ['ID', 'Int', 'Float'];
 
 interface Type {
   type: string;
@@ -104,6 +105,8 @@ export class TypeGraphQLVisitor<
 > extends TsVisitor<TRawConfig, TParsedConfig> {
   typescriptVisitor: TsVisitor<TRawConfig, TParsedConfig>;
 
+  libName: string;
+
   constructor(
     schema: GraphQLSchema,
     pluginConfig: TRawConfig,
@@ -131,11 +134,14 @@ export class TypeGraphQLVisitor<
         ...pluginConfig.decoratorName,
       },
       decorateTypes: pluginConfig.decorateTypes || undefined,
+      useNestJSGraphQL: pluginConfig.useNestJSGraphQL || false,
       ...additionalConfig,
     } as TParsedConfig);
     autoBind(this);
 
     this.typescriptVisitor = new TsVisitor(schema, pluginConfig, additionalConfig);
+
+    this.libName = this.config.useNestJSGraphQL ? 'NestJSGraphQL' : 'TypeGraphQL';
 
     const enumNames = Object.values(schema.getTypeMap())
       .map(type => (type instanceof GraphQLEnumType ? type.name : undefined))
@@ -240,7 +246,7 @@ export class TypeGraphQLVisitor<
         decoratorOptions.implements = interfaces[0];
       }
       declarationBlock = declarationBlock.withDecorator(
-        `@TypeGraphQL.${typeDecorator}(${formatDecoratorOptions(decoratorOptions)})`,
+        `@${this.libName}.${typeDecorator}(${formatDecoratorOptions(decoratorOptions)})`,
       );
     }
 
@@ -262,7 +268,7 @@ export class TypeGraphQLVisitor<
 
     // Add type-graphql InputType decorator
     declarationBlock = declarationBlock.withDecorator(
-      `@TypeGraphQL.${typeDecorator}(${formatDecoratorOptions(decoratorOptions)})`,
+      `@${this.libName}.${typeDecorator}(${formatDecoratorOptions(decoratorOptions)})`,
     );
 
     return declarationBlock.string;
@@ -291,7 +297,7 @@ export class TypeGraphQLVisitor<
     let declarationBlock = this.getArgumentsObjectDeclarationBlock(node, name, field);
 
     // Add type-graphql Args decorator
-    declarationBlock = declarationBlock.withDecorator(`@TypeGraphQL.${typeDecorator}()`);
+    declarationBlock = declarationBlock.withDecorator(`@${this.libName}.${typeDecorator}()`);
 
     return declarationBlock.string;
   }
@@ -314,7 +320,7 @@ export class TypeGraphQLVisitor<
       node,
       originalNode,
     ).withDecorator(
-      `@TypeGraphQL.${interfaceDecorator}(${formatDecoratorOptions(decoratorOptions)})`,
+      `@${this.libName}.${interfaceDecorator}(${formatDecoratorOptions(decoratorOptions)})`,
     );
 
     return [declarationBlock.string, this.buildArgumentsBlock(originalNode)]
@@ -372,9 +378,9 @@ export class TypeGraphQLVisitor<
     const singularNonNullableType = singularType.replace(MAYBE_REGEX, '$1');
     const isScalar = !!singularNonNullableType.match(SCALAR_REGEX);
     const type = singularNonNullableType.replace(SCALAR_REGEX, (match, type) => {
-      if (TYPE_GRAPHQL_SCALARS.includes(type)) {
-        // This is a TypeGraphQL type
-        return `TypeGraphQL.${type}`;
+      if (GRAPHQL_SCALARS.includes(type)) {
+        // This is a lib type
+        return `${this.libName}.${type}`;
       }
       if (global[type]) {
         // This is a JS native type
@@ -429,7 +435,7 @@ export class TypeGraphQLVisitor<
     const decorator =
       '\n' +
       indent(
-        `@TypeGraphQL.${fieldDecorator}(type => ${
+        `@${this.libName}.${fieldDecorator}(type => ${
           type.isArray ? `[${type.type}]` : type.type
         }${formatDecoratorOptions(decoratorOptions, false)})`,
       ) +
@@ -464,8 +470,8 @@ export class TypeGraphQLVisitor<
 
     const type = this.parseType(rawType);
     const typeGraphQLType =
-      type.isScalar && TYPE_GRAPHQL_SCALARS.includes(type.type)
-        ? `TypeGraphQL.${type.type}`
+      type.isScalar && GRAPHQL_SCALARS.includes(type.type)
+        ? `${this.libName}.${type.type}`
         : type.type;
 
     const decoratorOptions = this.getDecoratorOptions(node);
@@ -478,7 +484,7 @@ export class TypeGraphQLVisitor<
     const decorator =
       '\n' +
       indent(
-        `@TypeGraphQL.${fieldDecorator}(type => ${
+        `@${this.libName}.${fieldDecorator}(type => ${
           type.isArray ? `[${typeGraphQLType}]` : typeGraphQLType
         }${formatDecoratorOptions(decoratorOptions, false)})`,
       ) +
@@ -506,7 +512,7 @@ export class TypeGraphQLVisitor<
 
     return (
       super.EnumTypeDefinition(node) +
-      `TypeGraphQL.registerEnumType(${this.convertName(node)}, { name: '${this.convertName(
+      `${this.libName}.registerEnumType(${this.convertName(node)}, { name: '${this.convertName(
         node,
       )}' });\n`
     );


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Presently, the @nestjs/graphql module shares a similar API interface with type-graphql. However, I encountered a scenario where I required the usage of nestjs graphql instead of type-graphql. To accommodate this, I introduced a configuration flag to switch from using type-graphql to @nestjs/graphql. All tests have successfully passed without the inclusion of a new plugin for @nestjs/graphql.given that the @nestjs/graphql implementation heavily relies on the type-graphql library, effectively behaving as a subtype of that library.
 
 no dependency needed to be added 

## Type of change


- [ ] New feature (non-breaking change which adds functionality)

- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] type-graphql.spec

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


