### PR TITLE
fix(react-query): importOperationTypesFrom missing prefix

### DIFF
--- a/.changeset/dirty-donuts-invite.md
+++ b/.changeset/dirty-donuts-invite.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': minor
+---
+
+Fix importOperationTypesFrom missing prefix

--- a/packages/plugins/typescript/react-query/src/config.ts
+++ b/packages/plugins/typescript/react-query/src/config.ts
@@ -124,7 +124,6 @@ export interface ReactQueryRawPluginConfig
       | 'gqlImport'
       | 'documentNodeImport'
       | 'noExport'
-      | 'importOperationTypesFrom'
       | 'importDocumentNodeExternallyFrom'
       | 'useTypeImports'
       | 'legacyMode'

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -139,14 +139,11 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
     const generateConfig: GenerateConfig = {
       node,
       documentVariableName,
-      operationResultType,
-      operationVariablesTypes,
+      operationResultType: this._externalImportPrefix + operationResultType,
+      operationVariablesTypes: this._externalImportPrefix + operationVariablesTypes,
       hasRequiredVariables,
       operationName,
     };
-
-    operationResultType = this._externalImportPrefix + operationResultType;
-    operationVariablesTypes = this._externalImportPrefix + operationVariablesTypes;
 
     const queries: string[] = [];
     const getOutputFromQueries = () => `\n${queries.join('\n\n')}\n`;

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -1173,6 +1173,126 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
 ]
 `;
 
+exports[`React-Query support import-type preset in v4: content 1`] = `
+"
+
+export const TestDocument = \`
+    query test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+
+export const useTestQuery = <
+      TData = Types.TestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      variables?: Types.TestQueryVariables,
+      options?: UseQueryOptions<Types.TestQuery, TError, TData>
+    ) => {
+    
+    return useQuery<Types.TestQuery, TError, TData>(
+      variables === undefined ? ['test'] : ['test', variables],
+      fetcher<Types.TestQuery, Types.TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+      options
+    )};
+
+export const TestDocument = \`
+    mutation test($name: String) {
+  submitRepository(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      options?: UseMutationOptions<Types.TestMutation, TError, Types.TestMutationVariables, TContext>
+    ) => {
+    
+    return useMutation<Types.TestMutation, TError, Types.TestMutationVariables, TContext>(
+      ['test'],
+      (variables?: Types.TestMutationVariables) => fetcher<Types.TestMutation, Types.TestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
+      options
+    )};
+"
+`;
+
+exports[`React-Query support import-type preset in v5: content 1`] = `
+"
+
+export const TestDocument = \`
+    query test {
+  feed {
+    id
+    commentCount
+    repository {
+      full_name
+      html_url
+      owner {
+        avatar_url
+      }
+    }
+  }
+}
+    \`;
+
+export const useTestQuery = <
+      TData = Types.TestQuery,
+      TError = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      variables?: Types.TestQueryVariables,
+      options?: Omit<UseQueryOptions<Types.TestQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<Types.TestQuery, TError, TData>['queryKey'] }
+    ) => {
+    
+    return useQuery<Types.TestQuery, TError, TData>(
+      {
+    queryKey: variables === undefined ? ['test'] : ['test', variables],
+    queryFn: fetcher<Types.TestQuery, Types.TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
+    ...options
+  }
+    )};
+
+export const TestDocument = \`
+    mutation test($name: String) {
+  submitRepository(repoFullName: $name) {
+    id
+  }
+}
+    \`;
+
+export const useTestMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      dataSource: { endpoint: string, fetchParams?: RequestInit },
+      options?: UseMutationOptions<Types.TestMutation, TError, Types.TestMutationVariables, TContext>
+    ) => {
+    
+    return useMutation<Types.TestMutation, TError, Types.TestMutationVariables, TContext>(
+      {
+    mutationKey: ['test'],
+    mutationFn: (variables?: Types.TestMutationVariables) => fetcher<Types.TestMutation, Types.TestMutationVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables)(),
+    ...options
+  }
+    )};
+"
+`;
+
 exports[`React-Query support v4 syntax: content 1`] = `
 "
 

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -51,6 +51,29 @@ describe('React-Query', () => {
     await validateTypeScript(mergeOutputs(out), schema, docs, config);
   });
 
+  it('support import-type preset in v4', async () => {
+    const config: ReactQueryRawPluginConfig & { importOperationTypesFrom: string } = {
+      importOperationTypesFrom: 'Types',
+    };
+
+    const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+
+    expect(out.content).toMatchSnapshot('content');
+    await validateTypeScript(mergeOutputs(out), schema, docs, config);
+  });
+
+  it('support import-type preset in v5', async () => {
+    const config: ReactQueryRawPluginConfig & { importOperationTypesFrom: string } = {
+      reactQueryVersion: 5,
+      importOperationTypesFrom: 'Types',
+    };
+
+    const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
+
+    expect(out.content).toMatchSnapshot('content');
+    await validateTypeScript(mergeOutputs(out), schema, docs, config);
+  });
+
   it('Duplicated nested fragments are removed', async () => {
     const schema = buildSchema(/* GraphQL */ `
       schema {

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -52,7 +52,7 @@ describe('React-Query', () => {
   });
 
   it('support import-type preset in v4', async () => {
-    const config: ReactQueryRawPluginConfig & { importOperationTypesFrom: string } = {
+    const config: ReactQueryRawPluginConfig = {
       importOperationTypesFrom: 'Types',
     };
 
@@ -63,7 +63,7 @@ describe('React-Query', () => {
   });
 
   it('support import-type preset in v5', async () => {
-    const config: ReactQueryRawPluginConfig & { importOperationTypesFrom: string } = {
+    const config: ReactQueryRawPluginConfig = {
       reactQueryVersion: 5,
       importOperationTypesFrom: 'Types',
     };


### PR DESCRIPTION
## Description

Fix `importOperationTypesFrom` missing prefix.

Related #493 #434 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further Messages:
Thanks all of you who help to test and find issue for 6.0.0!
Special thanks to @knoefel for digging into the code and @groomain for creating the test repo!