### PR TITLE
fix(typescript-vue-apollo): make lazy query's variables optional

### DIFF
--- a/.changeset/fuzzy-cars-stare.md
+++ b/.changeset/fuzzy-cars-stare.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-vue-apollo": patch
+---
+
+Make lazy query's variables optional

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -521,10 +521,10 @@ export function useCommentQuery(
   );
 }
 export function useCommentLazyQuery(
-  variables:
+  variables?:
     | CommentQueryVariables
     | VueCompositionApi.Ref<CommentQueryVariables>
-    | ReactiveFunction<CommentQueryVariables> = {},
+    | ReactiveFunction<CommentQueryVariables>,
   options:
     | VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>
     | VueCompositionApi.Ref<
@@ -664,10 +664,10 @@ export function useFeedQuery(
   );
 }
 export function useFeedLazyQuery(
-  variables:
+  variables?:
     | FeedQueryVariables
     | VueCompositionApi.Ref<FeedQueryVariables>
-    | ReactiveFunction<FeedQueryVariables> = {},
+    | ReactiveFunction<FeedQueryVariables>,
   options:
     | VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>
     | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -524,7 +524,7 @@ export function useCommentLazyQuery(
   variables:
     | CommentQueryVariables
     | VueCompositionApi.Ref<CommentQueryVariables>
-    | ReactiveFunction<CommentQueryVariables>,
+    | ReactiveFunction<CommentQueryVariables> = {},
   options:
     | VueApolloComposable.UseQueryOptions<CommentQuery, CommentQueryVariables>
     | VueCompositionApi.Ref<
@@ -667,7 +667,7 @@ export function useFeedLazyQuery(
   variables:
     | FeedQueryVariables
     | VueCompositionApi.Ref<FeedQueryVariables>
-    | ReactiveFunction<FeedQueryVariables>,
+    | ReactiveFunction<FeedQueryVariables> = {},
   options:
     | VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>
     | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>>

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -245,15 +245,13 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<
         useTypesPrefix: false,
       });
 
-      const lazyOperationType = 'LazyQuery';
-
       compositionFunctions.push(
         this.buildCompositionFunction({
           operationName: lazyOperationName,
-          operationType: lazyOperationType,
+          operationType: 'LazyQuery',
           operationResultType,
           operationVariablesTypes,
-          operationHasNonNullableVariable,
+          operationHasNonNullableVariable: false,
           operationHasVariables,
           documentNodeVariable,
         }),

--- a/packages/plugins/typescript/vue-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/vue-apollo/src/visitor.ts
@@ -251,7 +251,7 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<
           operationType: 'LazyQuery',
           operationResultType,
           operationVariablesTypes,
-          operationHasNonNullableVariable: false,
+          operationHasNonNullableVariable,
           operationHasVariables,
           documentNodeVariable,
         }),
@@ -276,8 +276,10 @@ export class VueApolloVisitor extends ClientSideBaseVisitor<
     operationHasVariables,
     documentNodeVariable,
   }: BuildCompositionFunctions): string {
+    const operationVariablesOptionalModifier =
+      operationType === 'LazyQuery' && operationHasNonNullableVariable ? '?' : '';
     const variables = operationHasVariables
-      ? `variables: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>${
+      ? `variables${operationVariablesOptionalModifier}: ${operationVariablesTypes} | VueCompositionApi.Ref<${operationVariablesTypes}> | ReactiveFunction<${operationVariablesTypes}>${
           operationHasNonNullableVariable ? '' : ' = {}'
         }, `
       : '';

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -876,7 +876,7 @@ query MyFeed {
 
       // lazy query with optional variables, see https://github.com/dotansimha/graphql-code-generator-community/issues/438
       expect(content.content).toBeSimilarStringTo(
-        `export function useFeedLazyQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables> = {}, options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
+        `export function useFeedLazyQuery(variables?: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables>, options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
            return VueApolloComposable.useLazyQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
         }`,
       );

--- a/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
+++ b/packages/plugins/typescript/vue-apollo/tests/vue-apollo.spec.ts
@@ -874,9 +874,9 @@ query MyFeed {
         }`,
       );
 
-      // lazy query with required variables
+      // lazy query with optional variables, see https://github.com/dotansimha/graphql-code-generator-community/issues/438
       expect(content.content).toBeSimilarStringTo(
-        `export function useFeedLazyQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables>, options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
+        `export function useFeedLazyQuery(variables: FeedQueryVariables | VueCompositionApi.Ref<FeedQueryVariables> | ReactiveFunction<FeedQueryVariables> = {}, options: VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<FeedQuery, FeedQueryVariables>> = {}) {
            return VueApolloComposable.useLazyQuery<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options);
         }`,
       );


### PR DESCRIPTION
## Description

Fixes #438.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests and integration tests were updated.

**Test Environment**:

- OS: Ubuntu 22.04
- `@graphql-codegen/typescript-vue-apollo`: 4.1.0
- NodeJS: 18.18.2

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
