### PR TITLE
fix(kotlin): Enum names must not contain typesPrefix or typesSuffix

### DIFF
--- a/.changeset/curly-brooms-hunt.md
+++ b/.changeset/curly-brooms-hunt.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/kotlin': patch
+---
+
+fix(kotlin) Omit typesSuffix in enum names.

--- a/packages/plugins/java/kotlin/src/visitor.ts
+++ b/packages/plugins/java/kotlin/src/visitor.ts
@@ -88,6 +88,7 @@ export class KotlinResolversVisitor extends BaseVisitor<
       return indent(
         `${this.convertName(node, {
           useTypesPrefix: false,
+          useTypesSuffix: false,
           transformUnderscore: true,
         })}("${this.getEnumValue(enumName, node.name.value)}")`,
       );

--- a/packages/plugins/java/kotlin/tests/kotlin.spec.ts
+++ b/packages/plugins/java/kotlin/tests/kotlin.spec.ts
@@ -23,6 +23,7 @@ describe('Kotlin', () => {
       username: String
       email: String
       name: String
+      role: UserRole = USER
       sort: ResultSort
       metadata: MetadataSearch
     }
@@ -154,6 +155,49 @@ describe('Kotlin', () => {
         }
       }`);
     });
+
+    it('Should omit typesPrefix/typesSuffix in enum names if the option is set', async () => {
+      const result = await plugin(
+        schema,
+        [],
+        { typesPrefix: 'Graphql', typesSuffix: 'Type' },
+        { outputFile: OUTPUT_FILE },
+      );
+
+      // language=kotlin
+      expect(result).toBeSimilarStringTo(`    enum class GraphqlUserRoleType(val label: String) {
+          Admin("ADMIN"),
+          User("USER"),
+          Editor("EDITOR");
+        
+        companion object {
+          @JvmStatic
+          fun valueOfLabel(label: String): GraphqlUserRoleType? {
+            return values().find { it.label == label }
+          }
+        }
+    }`);
+
+      // language=kotlin
+      expect(result).toBeSimilarStringTo(`data class GraphqlSearchUserTypeInput(
+    val username: String? = null,
+    val email: String? = null,
+    val name: String? = null,
+    val role: GraphqlUserRoleType? = GraphqlUserRoleType.USER,
+    val sort: GraphqlResultSortType? = null,
+    val metadata: GraphqlMetadataSearchTypeInput? = null
+  ) {
+    @Suppress("UNCHECKED_CAST")
+    constructor(args: Map<String, Any>) : this(
+        args["username"] as String?,
+        args["email"] as String?,
+        args["name"] as String?,
+        args["role"] as GraphqlUserRoleType? ?: GraphqlUserRoleType.USER,
+        args["sort"] as GraphqlResultSortType?,
+        args["metadata"]?.let { GraphqlMetadataSearchTypeInput(it as Map<String, Any>) }
+    )
+  }`);
+    });
   });
 
   describe('Input Types / Arguments', () => {
@@ -243,6 +287,7 @@ describe('Kotlin', () => {
           val username: String? = null,
           val email: String? = null,
           val name: String? = null,
+          val role: UserRole? = UserRole.USER,
           val sort: ResultSort? = null,
           val metadata: MetadataSearchInput? = null
         ) {
@@ -251,6 +296,7 @@ describe('Kotlin', () => {
               args["username"] as String?,
               args["email"] as String?,
               args["name"] as String?,
+              args["role"] as UserRole? ?: UserRole.USER,
               args["sort"] as ResultSort?,
               args["metadata"]?.let { MetadataSearchInput(it as Map<String, Any>) }
           )


### PR DESCRIPTION
## Description

When using `typesSuffix` with kotlin plugin, the enum Names are generated in enum class, but not when referencing them.

The schema:

```graphql
enum UserRole {
    ADMIN
    USER
    EDITOR
}

input SearchUser {
    username: String
    email: String
    name: String
    role: UserRole = USER
}
```

The generated code:

```kotlin
package kotlin

data class GraphqlSearchUserTypeInput(
    val email: String? = null,
    val name: String? = null,
    val role: GraphqlUserRoleType? = GraphqlUserRoleType.USER,
    val username: String? = null
) {
  ...
}

enum class GraphqlUserRoleType(val label: String) {
      ADMINType("ADMIN"),
      EDITORType("EDITOR"),
      USERType("USER");
  ...
}
```

The names should be `ADMIN`, `EDITOR` and `USER`, but they are suffixed with `typesSuffix`.
This end up in invalid code, because `val role: GraphqlUserRoleType? = GraphqlUserRoleType.USER,` does not include the suffix.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

- [Codesandbox](https://codesandbox.io/p/devbox/jolly-joana-9h936c?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522cls4cytdy00062v6guq4gnnx0%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522cls4cytdy00022v6ghhxi786f%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522cls4cytdy00042v6gx1p1aido%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522cls4cytdy00052v6gcb0xen49%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522cls4cytdy00022v6ghhxi786f%2522%253A%257B%2522id%2522%253A%2522cls4cytdy00022v6ghhxi786f%2522%252C%2522activeTabId%2522%253A%2522cls4dqxew00g02v6gy060jqr2%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cls4cytdy00012v6gq092h3cu%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fnode_modules%252Fgraphql%252Futilities%252FextendSchema.js%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A548%252C%2522endLineNumber%2522%253A548%252C%2522startColumn%2522%253A22%252C%2522endColumn%2522%253A22%257D%255D%252C%2522id%2522%253A%2522cls4dqxew00g02v6gy060jqr2%2522%252C%2522mode%2522%253A%2522temporary%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%257D%252C%2522cls4cytdy00052v6gcb0xen49%2522%253A%257B%2522id%2522%253A%2522cls4cytdy00052v6gcb0xen49%2522%252C%2522activeTabId%2522%253A%2522cls4drc3o00hz2v6gs6zrfa8e%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522SANDBOX_INFO%2522%252C%2522id%2522%253A%2522cls4drc3o00hz2v6gs6zrfa8e%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%252C%2522cls4cytdy00042v6gx1p1aido%2522%253A%257B%2522id%2522%253A%2522cls4cytdy00042v6gx1p1aido%2522%252C%2522activeTabId%2522%253A%2522cls4d72kv002n2v6gff90798s%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cls4cytdy00032v6gnet72l5e%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522start%2522%257D%252C%257B%2522id%2522%253A%2522cls4d72kv002n2v6gff90798s%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522cls4doo0m000hdlcw4ngy4ztt%2522%257D%255D%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

## How Has This Been Tested?

- [X] Should omit typesPrefix/typesSuffix in enum names if the option is set

**Test Environment**:

- OS: Linux
- `@graphql-codegen/kotlin`: 3.0.0
- NodeJS: v20.9.0

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules