### PR TITLE
Fix broken descriptions for nest plugin

### DIFF
--- a/.changeset/nervous-sheep-cheer.md
+++ b/.changeset/nervous-sheep-cheer.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-nest': patch
+---
+
+Fix generated descriptions for comments containing apostrophes

--- a/packages/plugins/typescript/nest/src/utils.ts
+++ b/packages/plugins/typescript/nest/src/utils.ts
@@ -6,7 +6,8 @@ export const escapeString = (str: string) =>
   "'" +
   String(str || '')
     .replace(/\\/g, '\\\\')
-    .replace(/'/g, "\\'") +
+    // eslint-disable-next-line no-useless-escape
+    .replace(/'/g, "'") +
   "'";
 
 export const formatDecoratorOptions = (options: DecoratorOptions, isFirstArgument = true) => {

--- a/packages/plugins/typescript/nest/tests/nest.spec.ts
+++ b/packages/plugins/typescript/nest/tests/nest.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import { buildSchema } from 'graphql';
 import { Types } from '@graphql-codegen/plugin-helpers';
 import '@graphql-codegen/testing';
@@ -835,6 +836,28 @@ describe('nest', () => {
 
          @Nest.Field(type => Nest.ID, { nullable: true })
          optionalId?: Maybe<Scalars['ID']>;
+       };`);
+  });
+
+  it('correctly generates descriptions for annotated arguments apostrophes', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        query(
+          """
+          Description with apostrophe's
+          """
+          namedId: ID!
+        ): Boolean!
+      }
+    `);
+
+    const result = await plugin(schema, [], {}, { outputFile: '' });
+
+    expect(result.content).toBeSimilarStringTo(` @Nest.ArgsType()
+       export class QueryQueryArgs {
+
+         @Nest.Field(type => Nest.ID, { description: 'Description with apostrophe\'s' })
+         namedId!: Scalars['ID'];
        };`);
   });
 });


### PR DESCRIPTION
## Description

Descriptions that contain `'` were being incorrectly escaped, and output as `\\'` instead of `\'`.

Related # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New test added to check the output of descriptions containing apostrophes.

**Test Environment**:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules