### PR TITLE
Fix unused parameter in generated code

### DIFF
--- a/.changeset/giant-avocados-teach.md
+++ b/.changeset/giant-avocados-teach.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-generic-sdk': patch
+---
+
+Fix unused parameter in generated code which caused TS errors for users of the package.

--- a/packages/plugins/typescript/generic-sdk/src/visitor.ts
+++ b/packages/plugins/typescript/generic-sdk/src/visitor.ts
@@ -137,13 +137,23 @@ export class GenericSdkVisitor extends ClientSideBaseVisitor<
 
     const documentNodeType =
       this.config.documentMode === DocumentMode.string ? 'string' : 'DocumentNode';
-    const resultData = this.config.rawRequest ? 'ExecutionResult<R, E>' : 'R';
-    const returnType = `Promise<${resultData}> | ${
-      usingObservable ? 'Observable' : 'AsyncIterable'
-    }<${resultData}>`;
 
-    return `export type Requester<C = {}, E = unknown> = <R, V>(doc: ${documentNodeType}, vars?: V, options?: C) => ${returnType}
+    if (this.config.rawRequest) {
+      return `export type Requester<C = {}, E = unknown> = <R, V>(doc: ${documentNodeType}, vars?: V, options?: C) => Promise<ExecutionResult<R, E>> | ${
+        usingObservable ? 'Observable' : 'AsyncIterable'
+      }<ExecutionResult<R, E>>
 export function getSdk<C, E>(requester: Requester<C, E>) {
+  return {
+${allPossibleActions.join(',\n')}
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;`;
+    }
+
+    return `export type Requester<C = {}> = <R, V>(doc: ${documentNodeType}, vars?: V, options?: C) => Promise<R> | ${
+      usingObservable ? 'Observable' : 'AsyncIterable'
+    }<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
 ${allPossibleActions.join(',\n')}
   };

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -237,8 +237,8 @@ export const Feed4Document = gql\`
   }
 }
     \`;
-export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
-export function getSdk<C, E>(requester: Requester<C, E>) {
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
       return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedQuery>;
@@ -486,8 +486,8 @@ export const FeedLiveDocument = gql\`
   }
 }
     \`;
-export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
-export function getSdk<C, E>(requester: Requester<C, E>) {
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
       return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedQuery>;
@@ -726,8 +726,8 @@ export const FeedLiveDocument = gql\`
   }
 }
     \`;
-export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | Observable<R>
-export function getSdk<C, E>(requester: Requester<C, E>) {
+export type Requester<C = {}> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | Observable<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
       return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedQuery>;
@@ -978,8 +978,8 @@ export const Feed4Document = \`
   }
 }
     \`;
-export type Requester<C = {}, E = unknown> = <R, V>(doc: string, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
-export function getSdk<C, E>(requester: Requester<C, E>) {
+export type Requester<C = {}> = <R, V>(doc: string, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export function getSdk<C>(requester: Requester<C>) {
   return {
     feed(variables?: FeedQueryVariables, options?: C): Promise<FeedQuery> {
       return requester<FeedQuery, FeedQueryVariables>(FeedDocument, variables, options) as Promise<FeedQuery>;


### PR DESCRIPTION
## Description

When using the default behavior (ie: config `rawRequest` as `false`), the generated code has a `E` unused variable which make TS yelling when TS options `noUnusedParameters` is `true`.

The fix is put that variable onlye when `rawRequest` is `true`.

Related https://github.com/dotansimha/graphql-code-generator-community/issues/453
This is replacement of https://github.com/dotansimha/graphql-code-generator-community/pull/454 (because OP doesn't reply)

I tried to add stuff inside `dev-test` but I failed to understand properly how can I achieve that. Happy to add them if someone point me to the right direction.

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The generated code doesn't include the variable so TypeScript is happy.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
