### PR TITLE
fix(react-apollo): variables to be required in query hook when some v…

### DIFF
--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1352,9 +1352,13 @@ export function useSubmitRepositoryMutation(baseOptions?: Apollo.MutationHookOpt
           },
         )) as Types.ComplexPluginOutput;
 
-        expect(result.content).toContain(
-          requiredVariables ? ' & { variables: FeedQueryVariables }' : '',
-        );
+        const requiredVariableString = ' & { variables: FeedQueryVariables }';
+
+        if (requiredVariables) {
+          expect(result.content).toContain(requiredVariableString);
+        } else {
+          expect(result.content).not.toContain(requiredVariableString);
+        }
 
         await validateTypeScript(result, schema, docs, {});
       },

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1296,6 +1296,33 @@ export function useSubmitRepositoryMutation(baseOptions?: Apollo.MutationHookOpt
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('Should have variables as required if query contains required variables', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed($id: String!) {
+          feed(id: $id) {
+            id
+          }
+        }
+      `);
+      const docs = [{ location: '', document: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        },
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`
+export function useFeedQuery(baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> & { variables: FeedQueryVariables }) {
+  const options = {...defaultOptions, ...baseOptions}
+  return Apollo.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
+}`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('Should generate deduped hooks for query and mutation', async () => {
       const documents = parse(/* GraphQL */ `
         query FeedQuery {


### PR DESCRIPTION
## Description

Currently when a query has required variables, the passing of `variables` object isn't enforced in query hook args. This can cause runtime errors as if one doesn't specify the variables object at all, the types all are happy.

This PR introduces a proposed fix to ensure that variables need to be passed in args, when there are some required variables in the query. Similar has been done already for the [component generation](https://github.com/dotansimha/graphql-code-generator-community/blob/main/packages/plugins/typescript/react-apollo/src/visitor.ts#L306), but looks like this wasn't taken into account then.

Related https://github.com/dotansimha/graphql-code-generator/issues/2870

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

There are new test cases ensuring that variables added as a required field instead of optional, when some of the query variables are required.

I ran the tests locally and saw that they passed.

**Test Environment**:

- OS:
- `@graphql-codegen/typescript-react-apollo`: 4.2.0
- NodeJS: v18.19.0

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
