### PR TITLE
Fix/required variables in query hook

### DIFF
--- a/.changeset/plenty-ads-destroy.md
+++ b/.changeset/plenty-ads-destroy.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/typescript-react-apollo': minor
+---
+
+Improved type-safety: when a query contains required variables, passing the variables object to the
+useQuery hook is enforced

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -423,7 +423,8 @@ export function useOnCommentAddedSubscription(
   baseOptions: Apollo.SubscriptionHookOptions<
     OnCommentAddedSubscriptionMyOperation,
     OnCommentAddedSubscriptionVariables
-  > & { variables: OnCommentAddedSubscriptionVariables },
+  > &
+    ({ variables: OnCommentAddedSubscriptionVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useSubscription<
@@ -484,9 +485,8 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: Apollo.QueryHookOptions<CommentQueryMyOperation, CommentQueryVariables> & {
-    variables: CommentQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<CommentQueryMyOperation, CommentQueryVariables> &
+    ({ variables: CommentQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<CommentQueryMyOperation, CommentQueryVariables>(CommentDocument, options);
@@ -615,9 +615,8 @@ export const FeedDocument = gql`
  * });
  */
 export function useFeedQuery(
-  baseOptions: Apollo.QueryHookOptions<FeedQueryMyOperation, FeedQueryVariables> & {
-    variables: FeedQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<FeedQueryMyOperation, FeedQueryVariables> &
+    ({ variables: FeedQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FeedQueryMyOperation, FeedQueryVariables>(FeedDocument, options);

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -423,7 +423,7 @@ export function useOnCommentAddedSubscription(
   baseOptions: Apollo.SubscriptionHookOptions<
     OnCommentAddedSubscriptionMyOperation,
     OnCommentAddedSubscriptionVariables
-  >,
+  > & { variables: OnCommentAddedSubscriptionVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useSubscription<
@@ -484,7 +484,9 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: Apollo.QueryHookOptions<CommentQueryMyOperation, CommentQueryVariables>,
+  baseOptions: Apollo.QueryHookOptions<CommentQueryMyOperation, CommentQueryVariables> & {
+    variables: CommentQueryVariables;
+  },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<CommentQueryMyOperation, CommentQueryVariables>(CommentDocument, options);
@@ -613,7 +615,9 @@ export const FeedDocument = gql`
  * });
  */
 export function useFeedQuery(
-  baseOptions: Apollo.QueryHookOptions<FeedQueryMyOperation, FeedQueryVariables>,
+  baseOptions: Apollo.QueryHookOptions<FeedQueryMyOperation, FeedQueryVariables> & {
+    variables: FeedQueryVariables;
+  },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FeedQueryMyOperation, FeedQueryVariables>(FeedDocument, options);

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -469,7 +469,8 @@ export function useOnCommentAddedSubscription(
   baseOptions: Apollo.SubscriptionHookOptions<
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables
-  > & { variables: OnCommentAddedSubscriptionVariables },
+  > &
+    ({ variables: OnCommentAddedSubscriptionVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useSubscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>(
@@ -530,9 +531,8 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> & {
-    variables: CommentQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> &
+    ({ variables: CommentQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
@@ -655,9 +655,8 @@ export const FeedDocument = gql`
  * });
  */
 export function useFeedQuery(
-  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> & {
-    variables: FeedQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> &
+    ({ variables: FeedQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -469,7 +469,7 @@ export function useOnCommentAddedSubscription(
   baseOptions: Apollo.SubscriptionHookOptions<
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables
-  >,
+  > & { variables: OnCommentAddedSubscriptionVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useSubscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>(
@@ -530,7 +530,9 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables>,
+  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> & {
+    variables: CommentQueryVariables;
+  },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
@@ -652,7 +654,11 @@ export const FeedDocument = gql`
  *   },
  * });
  */
-export function useFeedQuery(baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables>) {
+export function useFeedQuery(
+  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> & {
+    variables: FeedQueryVariables;
+  },
+) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -423,7 +423,8 @@ export function useOnCommentAddedSubscription(
   baseOptions: Apollo.SubscriptionHookOptions<
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables
-  > & { variables: OnCommentAddedSubscriptionVariables },
+  > &
+    ({ variables: OnCommentAddedSubscriptionVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useSubscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>(
@@ -484,9 +485,8 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> & {
-    variables: CommentQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> &
+    ({ variables: CommentQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
@@ -609,9 +609,8 @@ export const FeedDocument = gql`
  * });
  */
 export function useFeedQuery(
-  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> & {
-    variables: FeedQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> &
+    ({ variables: FeedQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -423,7 +423,7 @@ export function useOnCommentAddedSubscription(
   baseOptions: Apollo.SubscriptionHookOptions<
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables
-  >,
+  > & { variables: OnCommentAddedSubscriptionVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useSubscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>(
@@ -484,7 +484,9 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables>,
+  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> & {
+    variables: CommentQueryVariables;
+  },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
@@ -606,7 +608,11 @@ export const FeedDocument = gql`
  *   },
  * });
  */
-export function useFeedQuery(baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables>) {
+export function useFeedQuery(
+  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> & {
+    variables: FeedQueryVariables;
+  },
+) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -423,7 +423,8 @@ export function useOnCommentAddedSubscription(
   baseOptions: Apollo.SubscriptionHookOptions<
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables
-  > & { variables: OnCommentAddedSubscriptionVariables },
+  > &
+    ({ variables: OnCommentAddedSubscriptionVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useSubscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>(
@@ -484,9 +485,8 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> & {
-    variables: CommentQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> &
+    ({ variables: CommentQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
@@ -609,9 +609,8 @@ export const FeedDocument = gql`
  * });
  */
 export function useFeedQuery(
-  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> & {
-    variables: FeedQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> &
+    ({ variables: FeedQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -423,7 +423,7 @@ export function useOnCommentAddedSubscription(
   baseOptions: Apollo.SubscriptionHookOptions<
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables
-  >,
+  > & { variables: OnCommentAddedSubscriptionVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useSubscription<OnCommentAddedSubscription, OnCommentAddedSubscriptionVariables>(
@@ -484,7 +484,9 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables>,
+  baseOptions: Apollo.QueryHookOptions<CommentQuery, CommentQueryVariables> & {
+    variables: CommentQueryVariables;
+  },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
@@ -606,7 +608,11 @@ export const FeedDocument = gql`
  *   },
  * });
  */
-export function useFeedQuery(baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables>) {
+export function useFeedQuery(
+  baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> & {
+    variables: FeedQueryVariables;
+  },
+) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }

--- a/dev-test/githunt/types.reactApollo.v2.tsx
+++ b/dev-test/githunt/types.reactApollo.v2.tsx
@@ -424,7 +424,7 @@ export function useOnCommentAddedSubscription(
   baseOptions: ApolloReactHooks.SubscriptionHookOptions<
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables
-  >,
+  > & { variables: OnCommentAddedSubscriptionVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useSubscription<
@@ -485,7 +485,9 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: ApolloReactHooks.QueryHookOptions<CommentQuery, CommentQueryVariables>,
+  baseOptions: ApolloReactHooks.QueryHookOptions<CommentQuery, CommentQueryVariables> & {
+    variables: CommentQueryVariables;
+  },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
@@ -614,7 +616,9 @@ export const FeedDocument = gql`
  * });
  */
 export function useFeedQuery(
-  baseOptions: ApolloReactHooks.QueryHookOptions<FeedQuery, FeedQueryVariables>,
+  baseOptions: ApolloReactHooks.QueryHookOptions<FeedQuery, FeedQueryVariables> & {
+    variables: FeedQueryVariables;
+  },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);

--- a/dev-test/githunt/types.reactApollo.v2.tsx
+++ b/dev-test/githunt/types.reactApollo.v2.tsx
@@ -424,7 +424,8 @@ export function useOnCommentAddedSubscription(
   baseOptions: ApolloReactHooks.SubscriptionHookOptions<
     OnCommentAddedSubscription,
     OnCommentAddedSubscriptionVariables
-  > & { variables: OnCommentAddedSubscriptionVariables },
+  > &
+    ({ variables: OnCommentAddedSubscriptionVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useSubscription<
@@ -485,9 +486,8 @@ export const CommentDocument = gql`
  * });
  */
 export function useCommentQuery(
-  baseOptions: ApolloReactHooks.QueryHookOptions<CommentQuery, CommentQueryVariables> & {
-    variables: CommentQueryVariables;
-  },
+  baseOptions: ApolloReactHooks.QueryHookOptions<CommentQuery, CommentQueryVariables> &
+    ({ variables: CommentQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
@@ -616,9 +616,8 @@ export const FeedDocument = gql`
  * });
  */
 export function useFeedQuery(
-  baseOptions: ApolloReactHooks.QueryHookOptions<FeedQuery, FeedQueryVariables> & {
-    variables: FeedQueryVariables;
-  },
+  baseOptions: ApolloReactHooks.QueryHookOptions<FeedQuery, FeedQueryVariables> &
+    ({ variables: FeedQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -52,7 +52,7 @@ export function useHeroNameConditionalInclusionQuery(
   baseOptions: Apollo.QueryHookOptions<
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables
-  >,
+  > & { variables: HeroNameConditionalInclusionQueryVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -126,7 +126,7 @@ export function useHeroNameConditionalExclusionQuery(
   baseOptions: Apollo.QueryHookOptions<
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables
-  >,
+  > & { variables: HeroNameConditionalExclusionQueryVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -52,7 +52,8 @@ export function useHeroNameConditionalInclusionQuery(
   baseOptions: Apollo.QueryHookOptions<
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables
-  > & { variables: HeroNameConditionalInclusionQueryVariables },
+  > &
+    ({ variables: HeroNameConditionalInclusionQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -126,7 +127,8 @@ export function useHeroNameConditionalExclusionQuery(
   baseOptions: Apollo.QueryHookOptions<
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables
-  > & { variables: HeroNameConditionalExclusionQueryVariables },
+  > &
+    ({ variables: HeroNameConditionalExclusionQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -670,7 +670,8 @@ export function useHeroNameConditionalInclusionQuery(
   baseOptions: Apollo.QueryHookOptions<
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables
-  > & { variables: HeroNameConditionalInclusionQueryVariables },
+  > &
+    ({ variables: HeroNameConditionalInclusionQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -749,7 +750,8 @@ export function useHeroNameConditionalExclusionQuery(
   baseOptions: Apollo.QueryHookOptions<
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables
-  > & { variables: HeroNameConditionalExclusionQueryVariables },
+  > &
+    ({ variables: HeroNameConditionalExclusionQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -670,7 +670,7 @@ export function useHeroNameConditionalInclusionQuery(
   baseOptions: Apollo.QueryHookOptions<
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables
-  >,
+  > & { variables: HeroNameConditionalInclusionQueryVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -749,7 +749,7 @@ export function useHeroNameConditionalExclusionQuery(
   baseOptions: Apollo.QueryHookOptions<
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables
-  >,
+  > & { variables: HeroNameConditionalExclusionQueryVariables },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<

--- a/dev-test/test-message/types.tsx
+++ b/dev-test/test-message/types.tsx
@@ -122,7 +122,9 @@ export type EscalateMutation = {
  * });
  */
 export function useGetMessagesQuery(
-  baseOptions: Apollo.QueryHookOptions<GetMessagesQuery, GetMessagesQueryVariables>,
+  baseOptions: Apollo.QueryHookOptions<GetMessagesQuery, GetMessagesQueryVariables> & {
+    variables: GetMessagesQueryVariables;
+  },
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetMessagesQuery, GetMessagesQueryVariables>(

--- a/dev-test/test-message/types.tsx
+++ b/dev-test/test-message/types.tsx
@@ -122,9 +122,8 @@ export type EscalateMutation = {
  * });
  */
 export function useGetMessagesQuery(
-  baseOptions: Apollo.QueryHookOptions<GetMessagesQuery, GetMessagesQueryVariables> & {
-    variables: GetMessagesQueryVariables;
-  },
+  baseOptions: Apollo.QueryHookOptions<GetMessagesQuery, GetMessagesQueryVariables> &
+    ({ variables: GetMessagesQueryVariables; skip?: boolean } | { skip: boolean }),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetMessagesQuery, GetMessagesQueryVariables>(

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -390,7 +390,9 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<
       `export function use${operationName}(baseOptions${
         shouldEnforceRequiredVariables ? '' : '?'
       }: ${this.getApolloReactHooksIdentifier()}.${operationType}HookOptions<${operationResultType}, ${operationVariablesTypes}>${
-        !shouldEnforceRequiredVariables ? '' : ` & { variables: ${operationVariablesTypes} }`
+        !shouldEnforceRequiredVariables
+          ? ''
+          : ` & ({ variables: ${operationVariablesTypes}; skip?: boolean; } | { skip: boolean; }) `
       }) {
         const options = {...defaultOptions, ...baseOptions}
         return ${this.getApolloReactHooksIdentifier()}.use${operationType}<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1352,7 +1352,8 @@ export function useSubmitRepositoryMutation(baseOptions?: Apollo.MutationHookOpt
           },
         )) as Types.ComplexPluginOutput;
 
-        const requiredVariableString = ' & { variables: FeedQueryVariables }';
+        const requiredVariableString =
+          ' & ({ variables: FeedQueryVariables; skip?: boolean; } | { skip: boolean; }) ';
 
         if (requiredVariables) {
           expect(result.content).toContain(requiredVariableString);

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1352,9 +1352,13 @@ export function useSubmitRepositoryMutation(baseOptions?: Apollo.MutationHookOpt
           },
         )) as Types.ComplexPluginOutput;
 
-        expect(result.content).toContain(
-          requiredVariables ? ' & { variables: FeedQueryVariables }' : '',
-        );
+        const requiredVariableString = ' & { variables: FeedQueryVariables }';
+
+        if (requiredVariables) {
+          expect(result.content).toContain(requiredVariableString);
+        } else {
+          expect(result.content).not.toContain(requiredVariableString);
+        }
 
         await validateTypeScript(result, schema, docs, {});
       },

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1296,6 +1296,33 @@ export function useSubmitRepositoryMutation(baseOptions?: Apollo.MutationHookOpt
       await validateTypeScript(content, schema, docs, {});
     });
 
+    it('Should have variables as required if query contains required variables', async () => {
+      const documents = parse(/* GraphQL */ `
+        query feed($id: String!) {
+          feed(id: $id) {
+            id
+          }
+        }
+      `);
+      const docs = [{ location: '', document: documents }];
+
+      const content = (await plugin(
+        schema,
+        docs,
+        {},
+        {
+          outputFile: 'graphql.tsx',
+        },
+      )) as Types.ComplexPluginOutput;
+
+      expect(content.content).toBeSimilarStringTo(`
+export function useFeedQuery(baseOptions: Apollo.QueryHookOptions<FeedQuery, FeedQueryVariables> & { variables: FeedQueryVariables }) {
+  const options = {...defaultOptions, ...baseOptions}
+  return Apollo.useQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
+}`);
+      await validateTypeScript(content, schema, docs, {});
+    });
+
     it('Should generate deduped hooks for query and mutation', async () => {
       const documents = parse(/* GraphQL */ `
         query FeedQuery {


### PR DESCRIPTION
## Description

Currently when a query has required variables, the passing of `variables` object isn't enforced in query hook args. This can cause runtime errors as if one doesn't specify the variables object at all, the types all are happy.

This PR introduces a proposed fix to ensure that variables need to be passed in args, when there are some required variables in the query. Similar has been done already for the [component generation](https://github.com/dotansimha/graphql-code-generator-community/blob/main/packages/plugins/typescript/react-apollo/src/visitor.ts#L306), but looks like this wasn't taken into account then.

Related https://github.com/dotansimha/graphql-code-generator/issues/2870

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

There are new test cases ensuring that variables added as a required field instead of optional, when some of the query variables are required.

I ran the tests locally and saw that they passed.

**Test Environment**:

- OS: macOS
- `@graphql-codegen/typescript-react-apollo`: 4.2.0
- NodeJS: v18.19.0

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
