### PR TITLE
fix: add null validation for java enum arguments

### DIFF
--- a/.changeset/many-pens-talk.md
+++ b/.changeset/many-pens-talk.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/java': patch
+---
+
+Add null validation for enum arguments

--- a/packages/plugins/java/java/src/visitor.ts
+++ b/packages/plugins/java/java/src/visitor.ts
@@ -252,7 +252,7 @@ export class JavaResolversVisitor extends BaseVisitor<
           return indentMultiline(
             `if (args.get("${arg.name.value}") instanceof ${typeToUse.typeName}) {
   this.${this.config.classMembersPrefix}${arg.name.value} = (${typeToUse.typeName}) args.get("${arg.name.value}");
-} else {
+} else if (args.get("${arg.name.value}") != null) {
   this.${this.config.classMembersPrefix}${arg.name.value} = ${typeToUse.typeName}.valueOf((String) args.get("${arg.name.value}"));
 }`,
             3,

--- a/packages/plugins/java/java/tests/java.spec.ts
+++ b/packages/plugins/java/java/tests/java.spec.ts
@@ -242,7 +242,7 @@ describe('Java', () => {
       const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
       expect(result).toBeSimilarStringTo(`if (args.get("sort") instanceof ResultSort) {
         this.sort = (ResultSort) args.get("sort");
-      } else {
+      } else if (args.get("sort") != null) {
         this.sort = ResultSort.valueOf((String) args.get("sort"));
       }`);
     });
@@ -289,7 +289,7 @@ describe('Java', () => {
             this.dateOfBirth = (Object) args.get("dateOfBirth");
             if (args.get("sort") instanceof ResultSort) {
               this.sort = (ResultSort) args.get("sort");
-            } else {
+            } else if (args.get("sort") != null) {
               this.sort = ResultSort.valueOf((String) args.get("sort"));
             }
             this.metadata = new MetadataSearchInput((Map<String, Object>) args.get("metadata"));
@@ -422,7 +422,7 @@ describe('Java', () => {
     //   const result = await plugin(schema, [], {}, { outputFile: OUTPUT_FILE });
     //   expect(result).toBeSimilarStringTo(`if (args.get("sort") instanceof ResultSort) {
     //     this.sort = (ResultSort) args.get("sort");
-    //   } else {
+    //   } else if (args.get("sort") != null) {
     //     this.sort = ResultSort.valueOf((String) args.get("sort"));
     //   }`);
     // });


### PR DESCRIPTION
## Description

This fixes an issue with generated java query input arguments as enum values lacked null checks.

Related #637


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

https://stackblitz.com/edit/github-val3pw

## How Has This Been Tested?

Updated unit tests and tested locally that this fixes a problem in a project that I'm using this dependency for.


## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
