### PR TITLE
feat(typescript-vue-urql): Allow reactive query input

### DIFF
--- a/.changeset/eighty-garlics-repair.md
+++ b/.changeset/eighty-garlics-repair.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-codegen/typescript-vue-urql': minor
+'@graphql-codegen/typescript-vue-urql': major
 ---
 
 Allow vue reactive values as input for queries

--- a/.changeset/eighty-garlics-repair.md
+++ b/.changeset/eighty-garlics-repair.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-vue-urql': minor
+---
+
+Allow vue reactive values as input for queries

--- a/packages/plugins/typescript/vue-urql/src/config.ts
+++ b/packages/plugins/typescript/vue-urql/src/config.ts
@@ -17,4 +17,27 @@ export interface VueUrqlRawPluginConfig extends RawClientSideBasePluginConfig {
    * @default urql
    */
   urqlImportFrom?: string;
+  /**
+   * @name vueCompositionApiImportFrom
+   * @default vue
+   *
+   * @exampleMarkdown
+   * ```ts filename="codegen.ts"
+   *  import type { CodegenConfig } from '@graphql-codegen/cli';
+   *
+   *  const config: CodegenConfig = {
+   *    // ...
+   *    generates: {
+   *      'path/to/file.ts': {
+   *        plugins: ['typescript', 'typescript-operations', 'typescript-vue-urql'],
+   *        config: {
+   *          vueCompositionApiImportFrom: 'vue'
+   *        },
+   *      },
+   *    },
+   *  };
+   *  export default config;
+   * ```
+   */
+  vueCompositionApiImportFrom?: 'vue' | '@vue/composition-api' | string;
 }

--- a/packages/plugins/typescript/vue-urql/src/index.ts
+++ b/packages/plugins/typescript/vue-urql/src/index.ts
@@ -28,7 +28,7 @@ export const plugin: PluginFunction<VueUrqlRawPluginConfig, Types.ComplexPluginO
   const visitorResult = oldVisit(allAst, { leave: visitor });
 
   return {
-    prepend: [visitor.getImports(), visitor.getWrapperDefinitions()],
+    prepend: [...visitor.getImports(), ...visitor.getWrapperDefinitions()],
     content: [
       visitor.fragments,
       ...visitorResult.definitions.filter(t => typeof t === 'string'),

--- a/packages/plugins/typescript/vue-urql/src/index.ts
+++ b/packages/plugins/typescript/vue-urql/src/index.ts
@@ -28,7 +28,7 @@ export const plugin: PluginFunction<VueUrqlRawPluginConfig, Types.ComplexPluginO
   const visitorResult = oldVisit(allAst, { leave: visitor });
 
   return {
-    prepend: visitor.getImports(),
+    prepend: [visitor.getImports(), visitor.getWrapperDefinitions()],
     content: [
       visitor.fragments,
       ...visitorResult.definitions.filter(t => typeof t === 'string'),

--- a/packages/plugins/typescript/vue-urql/src/visitor.ts
+++ b/packages/plugins/typescript/vue-urql/src/visitor.ts
@@ -56,13 +56,6 @@ export class UrqlVisitor extends ClientSideBaseVisitor<VueUrqlRawPluginConfig, U
 
     autoBind(this);
   }
-  public getWrapperDefinitions(): string[] {
-    return [ALLOW_REACTIVE_SIGNATURE];
-  }
-
-  public getAllowReactiveDefinition(): string {
-    return `${this.getExportPrefix()}${ALLOW_REACTIVE_SIGNATURE}`;
-  }
 
   public getImports(): string[] {
     const baseImports = super.getImports();
@@ -80,6 +73,14 @@ export class UrqlVisitor extends ClientSideBaseVisitor<VueUrqlRawPluginConfig, U
     imports.push(OMIT_TYPE);
 
     return [...baseImports, ...imports];
+  }
+
+  public getWrapperDefinitions(): string[] {
+    return [this.getAllowReactiveDefinition()];
+  }
+
+  public getAllowReactiveDefinition(): string {
+    return `${ALLOW_REACTIVE_SIGNATURE}`;
   }
 
   private _buildCompositionFn(

--- a/packages/plugins/typescript/vue-urql/src/visitor.ts
+++ b/packages/plugins/typescript/vue-urql/src/visitor.ts
@@ -16,8 +16,8 @@ export interface UrqlPluginConfig extends ClientSideBasePluginConfig {
   urqlImportFrom: string;
 }
 
-export const ALLOW_REACTIVE_SIGNATURE = `type AllowReactiveInput<T> = {
-  [K in keyof T]: T[K] extends object ? AllowReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
+export const VUE_REACTIVE_INPUT_SIGNATURE = `type VueReactiveInput<T> = {
+  [K in keyof T]: T[K] extends object ? VueReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
 };`;
 
 export class UrqlVisitor extends ClientSideBaseVisitor<VueUrqlRawPluginConfig, UrqlPluginConfig> {
@@ -80,7 +80,7 @@ export class UrqlVisitor extends ClientSideBaseVisitor<VueUrqlRawPluginConfig, U
   }
 
   public getAllowReactiveDefinition(): string {
-    return `${ALLOW_REACTIVE_SIGNATURE}`;
+    return `${VUE_REACTIVE_INPUT_SIGNATURE}`;
   }
 
   private _buildCompositionFn(
@@ -110,8 +110,8 @@ export function use${operationName}<R = ${operationResultType}>(options: Omit<Ur
     }
 
     return `
-export function use${operationName}(options: Omit<Urql.Use${operationType}Args<never, AllowReactiveInput<${operationVariablesTypes}>>, 'query'>) {
-  return Urql.use${operationType}<${operationResultType}, AllowReactiveInput<${operationVariablesTypes}>>({ query: ${documentVariableName}, ...options });
+export function use${operationName}(options: Omit<Urql.Use${operationType}Args<never, VueReactiveInput<${operationVariablesTypes}>>, 'query'>) {
+  return Urql.use${operationType}<${operationResultType}, VueReactiveInput<${operationVariablesTypes}>>({ query: ${documentVariableName}, ...options });
 };`;
   }
 

--- a/packages/plugins/typescript/vue-urql/src/visitor.ts
+++ b/packages/plugins/typescript/vue-urql/src/visitor.ts
@@ -110,8 +110,8 @@ export function use${operationName}<R = ${operationResultType}>(options: Omit<Ur
     }
 
     return `
-export function use${operationName}(options: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes}>, 'query'>) {
-  return Urql.use${operationType}<${operationResultType}, ${operationVariablesTypes}>({ query: ${documentVariableName}, ...options });
+export function use${operationName}(options: Omit<Urql.Use${operationType}Args<never, AllowReactiveInput<${operationVariablesTypes}>>, 'query'>) {
+  return Urql.use${operationType}<${operationResultType}, AllowReactiveInput<${operationVariablesTypes}>>({ query: ${documentVariableName}, ...options });
 };`;
   }
 

--- a/packages/plugins/typescript/vue-urql/src/visitor.ts
+++ b/packages/plugins/typescript/vue-urql/src/visitor.ts
@@ -16,6 +16,10 @@ export interface UrqlPluginConfig extends ClientSideBasePluginConfig {
   urqlImportFrom: string;
 }
 
+export const ALLOW_REACTIVE_SIGNATURE = `type AllowReactiveInput<T> = {
+  [K in keyof T]: T[K] extends object ? AllowReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
+};`;
+
 export class UrqlVisitor extends ClientSideBaseVisitor<VueUrqlRawPluginConfig, UrqlPluginConfig> {
   private _externalImportPrefix = '';
 
@@ -51,6 +55,13 @@ export class UrqlVisitor extends ClientSideBaseVisitor<VueUrqlRawPluginConfig, U
     }
 
     autoBind(this);
+  }
+  public getWrapperDefinitions(): string[] {
+    return [ALLOW_REACTIVE_SIGNATURE];
+  }
+
+  public getAllowReactiveDefinition(): string {
+    return `${this.getExportPrefix()}${ALLOW_REACTIVE_SIGNATURE}`;
   }
 
   public getImports(): string[] {

--- a/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
@@ -4,8 +4,8 @@ exports[`urql Composition Should generate subscription hooks 1`] = `
 "import gql from 'graphql-tag';
 import * as Urql from '@urql/vue';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type AllowReactiveInput<T> = {
-  [K in keyof T]: T[K] extends object ? AllowReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
+type VueReactiveInput<T> = {
+  [K in keyof T]: T[K] extends object ? VueReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
 };
 
 export const ListenToCommentsDocument = gql\`
@@ -25,12 +25,12 @@ exports[`urql Composition should allow importing operations and documents from a
 "import * as Operations from '@myproject/generated';
 import * as Urql from '@urql/vue';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type AllowReactiveInput<T> = {
-  [K in keyof T]: T[K] extends object ? AllowReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
+type VueReactiveInput<T> = {
+  [K in keyof T]: T[K] extends object ? VueReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
 };
 
 
-export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, AllowReactiveInput<Operations.TestQueryVariables>>, 'query'>) {
-  return Urql.useQuery<Operations.TestQuery, AllowReactiveInput<Operations.TestQueryVariables>>({ query: Operations.TestDocument, ...options });
+export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, VueReactiveInput<Operations.TestQueryVariables>>, 'query'>) {
+  return Urql.useQuery<Operations.TestQuery, VueReactiveInput<Operations.TestQueryVariables>>({ query: Operations.TestDocument, ...options });
 };"
 `;

--- a/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
@@ -3,9 +3,10 @@
 exports[`urql Composition Should generate subscription hooks 1`] = `
 "import gql from 'graphql-tag';
 import * as Urql from '@urql/vue';
+import { Ref, ComputedRef } from 'vue';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type VueReactiveInput<T> = {
-  [K in keyof T]: T[K] extends object ? VueReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
+type WrapRefs<T> = {
+  [K in keyof T]: T[K] extends object ? WrapRefs<T[K]> | Ref<T[K]> | ComputedRef<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]>;
 };
 
 export const ListenToCommentsDocument = gql\`
@@ -24,13 +25,14 @@ export function useListenToCommentsSubscription<R = ListenToCommentsSubscription
 exports[`urql Composition should allow importing operations and documents from another file 1`] = `
 "import * as Operations from '@myproject/generated';
 import * as Urql from '@urql/vue';
+import { Ref, ComputedRef } from 'vue';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-type VueReactiveInput<T> = {
-  [K in keyof T]: T[K] extends object ? VueReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
+type WrapRefs<T> = {
+  [K in keyof T]: T[K] extends object ? WrapRefs<T[K]> | Ref<T[K]> | ComputedRef<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]>;
 };
 
 
-export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, VueReactiveInput<Operations.TestQueryVariables>>, 'query'>) {
-  return Urql.useQuery<Operations.TestQuery, VueReactiveInput<Operations.TestQueryVariables>>({ query: Operations.TestDocument, ...options });
+export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, WrapRefs<Operations.TestQueryVariables>>, 'query'>) {
+  return Urql.useQuery<Operations.TestQuery, WrapRefs<Operations.TestQueryVariables>>({ query: Operations.TestDocument, ...options });
 };"
 `;

--- a/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
@@ -4,6 +4,9 @@ exports[`urql Composition Should generate subscription hooks 1`] = `
 "import gql from 'graphql-tag';
 import * as Urql from '@urql/vue';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type AllowReactiveInput<T> = {
+  [K in keyof T]: T[K] extends object ? AllowReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
+};
 
 export const ListenToCommentsDocument = gql\`
     subscription ListenToComments($name: String) {
@@ -22,9 +25,12 @@ exports[`urql Composition should allow importing operations and documents from a
 "import * as Operations from '@myproject/generated';
 import * as Urql from '@urql/vue';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type AllowReactiveInput<T> = {
+  [K in keyof T]: T[K] extends object ? AllowReactiveInput<T[K]> | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]> : T[K] | Ref<T[K]> | ComputedRef<T[K]> | Reactive<T[K]>;
+};
 
 
-export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, Operations.TestQueryVariables>, 'query'>) {
-  return Urql.useQuery<Operations.TestQuery, Operations.TestQueryVariables>({ query: Operations.TestDocument, ...options });
+export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, AllowReactiveInput<Operations.TestQueryVariables>>, 'query'>) {
+  return Urql.useQuery<Operations.TestQuery, AllowReactiveInput<Operations.TestQueryVariables>>({ query: Operations.TestDocument, ...options });
 };"
 `;

--- a/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
@@ -477,8 +477,8 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, AllowReactiveInput<FeedQueryVariables>>, 'query'>) {
-  return Urql.useQuery<FeedQuery, AllowReactiveInput<FeedQueryVariables>>({ query: FeedDocument, ...options });
+export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, VueReactiveInput<FeedQueryVariables>>, 'query'>) {
+  return Urql.useQuery<FeedQuery, VueReactiveInput<FeedQueryVariables>>({ query: FeedDocument, ...options });
 };`);
 
       expect(content.content).toBeSimilarStringTo(`

--- a/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
@@ -477,8 +477,8 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, VueReactiveInput<FeedQueryVariables>>, 'query'>) {
-  return Urql.useQuery<FeedQuery, VueReactiveInput<FeedQueryVariables>>({ query: FeedDocument, ...options });
+export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, WrapRefs<FeedQueryVariables>>, 'query'>) {
+  return Urql.useQuery<FeedQuery, WrapRefs<FeedQueryVariables>>({ query: FeedDocument, ...options });
 };`);
 
       expect(content.content).toBeSimilarStringTo(`

--- a/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
@@ -477,8 +477,8 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, FeedQueryVariables>, 'query'>) {
-  return Urql.useQuery<FeedQuery, FeedQueryVariables>({ query: FeedDocument, ...options });
+export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, AllowReactiveInput<FeedQueryVariables>>, 'query'>) {
+  return Urql.useQuery<FeedQuery, AllowReactiveInput<FeedQueryVariables>>({ query: FeedDocument, ...options });
 };`);
 
       expect(content.content).toBeSimilarStringTo(`


### PR DESCRIPTION
## Description

Allows ref, reactive and computed as input for all query variables in the Urql composables.

Related #194 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Updated existing test in `urql.spec.ts`

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Further comments

I saw in other plugins use `this.getExportPrefix()` before the type definition, but since the vue-urql plugin visitor extends `ClientSideBaseVisitor` and not `TsVisitor` I was unsure how to proceed with this.
