### PR TITLE
Support `documentVariableSuffix` when using `documentMode: 'external'`

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -186,7 +186,7 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<
     documentVariableName: string,
   ): string {
     return this.config.documentMode === DocumentMode.external
-      ? `Operations.${node.name?.value ?? ''}`
+      ? `Operations.${node.name?.value ?? ''}${this.config.documentVariableSuffix}`
       : documentVariableName;
   }
 


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

This implements the fix suggested in https://github.com/dotansimha/graphql-code-generator-community/issues/141

This is correctly appending `Document` to the operations externally imported for me, which is fixing all compiler errors.

If there's a better way to support this, I'm open to suggestions, but this is working well for me. Will add tests etc if requested.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with a yarn patch on personal code.

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
