### PR TITLE
fix(typescript-graphql-request): Remove incorrect RequestInit import

### DIFF
--- a/packages/plugins/typescript/react-query/package.json
+++ b/packages/plugins/typescript/react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-codegen/typescript-react-query",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "type": "module",
   "description": "GraphQL Code Generator plugin for generating a ready-to-use React-Query Hooks based on GraphQL operations",
   "repository": {

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -69,9 +69,6 @@ function fetcher<TData, TVariables extends { [key: string]: any }>(client: Graph
     const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
     if (this.clientPath) this.visitor.imports.add(this.clientPath);
     this.visitor.imports.add(`${typeImport} { GraphQLClient } from 'graphql-request';`);
-    this.visitor.imports.add(
-      `${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`,
-    );
 
     const { generateBaseQueryHook, variables, options } = this.generateQueryHelper(
       config,
@@ -132,6 +129,7 @@ function fetcher<TData, TVariables extends { [key: string]: any }>(client: Graph
       config;
 
     const variables = this.generateQueryVariablesSignature(config);
+    if (this.clientPath) this.visitor.imports.add(this.clientPath);
 
     return this.clientPath
       ? `\nuse${operationName}.fetcher = (${variables}, headers?: RequestInit['headers']) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables, headers);`

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -132,11 +132,6 @@ function fetcher<TData, TVariables extends { [key: string]: any }>(client: Graph
       config;
 
     const variables = this.generateQueryVariablesSignature(config);
-    const typeImport = this.visitor.config.useTypeImports ? 'import type' : 'import';
-    if (this.clientPath) this.visitor.imports.add(this.clientPath);
-    this.visitor.imports.add(
-      `${typeImport} { RequestInit } from 'graphql-request/dist/types.dom';`,
-    );
 
     return this.clientPath
       ? `\nuse${operationName}.fetcher = (${variables}, headers?: RequestInit['headers']) => fetcher<${operationResultType}, ${operationVariablesTypes}>(${documentVariableName}, variables, headers);`

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -648,7 +648,6 @@ export const useTestMutation = <
 exports[`React-Query fetcher: graphql-request Should generate query correctly with client: prepend 1`] = `
 [
   "import { GraphQLClient } from 'graphql-request';",
-  "import { RequestInit } from 'graphql-request/dist/types.dom';",
   "import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions } from 'react-query';",
   "
 function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
@@ -723,7 +722,6 @@ exports[`React-Query fetcher: graphql-request with clientImportPath Should gener
 [
   "import { client as graphqlClient } from 'client.ts';",
   "import { GraphQLClient } from 'graphql-request';",
-  "import { RequestInit } from 'graphql-request/dist/types.dom';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';",
   "
 function fetcher<TData, TVariables extends { [key: string]: any }>(query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {


### PR DESCRIPTION
## Description

Related #367 
graphql-request has been updated to v6 and no longer export type `RequestInit` in `dist/types.dom`. It needs to be removed in the generated file.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Generate file locally

**Test Environment**:

- OS: MacOS 14.4.1
- NodeJS: 20.9.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
