### PR TITLE
feat: add skipToken option to useSuspenseQuery in react-apollo plugin

### DIFF
--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -501,9 +501,12 @@ export function useCommentLazyQuery(
   );
 }
 export function useCommentSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<CommentQueryMyOperation, CommentQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<CommentQueryMyOperation, CommentQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<CommentQueryMyOperation, CommentQueryVariables>(
     CommentDocument,
     options,
@@ -562,12 +565,15 @@ export function useCurrentUserForProfileLazyQuery(
   >(CurrentUserForProfileDocument, options);
 }
 export function useCurrentUserForProfileSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    CurrentUserForProfileQueryMyOperation,
-    CurrentUserForProfileQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        CurrentUserForProfileQueryMyOperation,
+        CurrentUserForProfileQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     CurrentUserForProfileQueryMyOperation,
     CurrentUserForProfileQueryVariables
@@ -628,9 +634,12 @@ export function useFeedLazyQuery(
   return Apollo.useLazyQuery<FeedQueryMyOperation, FeedQueryVariables>(FeedDocument, options);
 }
 export function useFeedSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<FeedQueryMyOperation, FeedQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<FeedQueryMyOperation, FeedQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<FeedQueryMyOperation, FeedQueryVariables>(FeedDocument, options);
 }
 export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -544,9 +544,12 @@ export function useCommentLazyQuery(
   return Apollo.useLazyQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
 }
 export function useCommentSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<CommentQuery, CommentQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<CommentQuery, CommentQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
 }
 export type CommentQueryHookResult = ReturnType<typeof useCommentQuery>;
@@ -602,12 +605,15 @@ export function useCurrentUserForProfileLazyQuery(
   );
 }
 export function useCurrentUserForProfileSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    CurrentUserForProfileQuery,
-    CurrentUserForProfileQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        CurrentUserForProfileQuery,
+        CurrentUserForProfileQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(
     CurrentUserForProfileDocument,
     options,
@@ -668,9 +674,10 @@ export function useFeedLazyQuery(
   return Apollo.useLazyQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }
 export function useFeedSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>,
+  baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }
 export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -498,9 +498,12 @@ export function useCommentLazyQuery(
   return Apollo.useLazyQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
 }
 export function useCommentSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<CommentQuery, CommentQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<CommentQuery, CommentQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
 }
 export type CommentQueryHookResult = ReturnType<typeof useCommentQuery>;
@@ -556,12 +559,15 @@ export function useCurrentUserForProfileLazyQuery(
   );
 }
 export function useCurrentUserForProfileSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    CurrentUserForProfileQuery,
-    CurrentUserForProfileQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        CurrentUserForProfileQuery,
+        CurrentUserForProfileQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(
     CurrentUserForProfileDocument,
     options,
@@ -622,9 +628,10 @@ export function useFeedLazyQuery(
   return Apollo.useLazyQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }
 export function useFeedSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>,
+  baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }
 export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -498,9 +498,12 @@ export function useCommentLazyQuery(
   return Apollo.useLazyQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
 }
 export function useCommentSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<CommentQuery, CommentQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<CommentQuery, CommentQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<CommentQuery, CommentQueryVariables>(CommentDocument, options);
 }
 export type CommentQueryHookResult = ReturnType<typeof useCommentQuery>;
@@ -556,12 +559,15 @@ export function useCurrentUserForProfileLazyQuery(
   );
 }
 export function useCurrentUserForProfileSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    CurrentUserForProfileQuery,
-    CurrentUserForProfileQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        CurrentUserForProfileQuery,
+        CurrentUserForProfileQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(
     CurrentUserForProfileDocument,
     options,
@@ -622,9 +628,10 @@ export function useFeedLazyQuery(
   return Apollo.useLazyQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }
 export function useFeedSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>,
+  baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }
 export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;

--- a/dev-test/githunt/types.reactApollo.v2.tsx
+++ b/dev-test/githunt/types.reactApollo.v2.tsx
@@ -502,9 +502,14 @@ export function useCommentLazyQuery(
   );
 }
 export function useCommentSuspenseQuery(
-  baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<CommentQuery, CommentQueryVariables>,
+  baseOptions?:
+    | ApolloReactHooks.SkipToken
+    | ApolloReactHooks.SuspenseQueryHookOptions<CommentQuery, CommentQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === ApolloReactHooks.skipToken
+      ? ApolloReactHooks.skipToken
+      : { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useSuspenseQuery<CommentQuery, CommentQueryVariables>(
     CommentDocument,
     options,
@@ -563,12 +568,17 @@ export function useCurrentUserForProfileLazyQuery(
   >(CurrentUserForProfileDocument, options);
 }
 export function useCurrentUserForProfileSuspenseQuery(
-  baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<
-    CurrentUserForProfileQuery,
-    CurrentUserForProfileQueryVariables
-  >,
+  baseOptions?:
+    | ApolloReactHooks.SkipToken
+    | ApolloReactHooks.SuspenseQueryHookOptions<
+        CurrentUserForProfileQuery,
+        CurrentUserForProfileQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === ApolloReactHooks.skipToken
+      ? ApolloReactHooks.skipToken
+      : { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useSuspenseQuery<
     CurrentUserForProfileQuery,
     CurrentUserForProfileQueryVariables
@@ -629,9 +639,14 @@ export function useFeedLazyQuery(
   return ApolloReactHooks.useLazyQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }
 export function useFeedSuspenseQuery(
-  baseOptions?: ApolloReactHooks.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>,
+  baseOptions?:
+    | ApolloReactHooks.SkipToken
+    | ApolloReactHooks.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === ApolloReactHooks.skipToken
+      ? ApolloReactHooks.skipToken
+      : { ...defaultOptions, ...baseOptions };
   return ApolloReactHooks.useSuspenseQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
 }
 export type FeedQueryHookResult = ReturnType<typeof useFeedQuery>;

--- a/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
+++ b/dev-test/star-wars/__generated__/HeroAndFriendsNames.tsx
@@ -79,12 +79,12 @@ export function useHeroAndFriendsNamesLazyQuery(
   );
 }
 export function useHeroAndFriendsNamesSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroAndFriendsNamesQuery,
-    HeroAndFriendsNamesQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>(
     HeroAndFriendsNamesDocument,
     options,

--- a/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
+++ b/dev-test/star-wars/__generated__/HeroAppearsIn.tsx
@@ -56,9 +56,12 @@ export function useHeroAppearsInLazyQuery(
   );
 }
 export function useHeroAppearsInSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<HeroAppearsInQuery, HeroAppearsInQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HeroAppearsInQuery, HeroAppearsInQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HeroAppearsInQuery, HeroAppearsInQueryVariables>(
     HeroAppearsInDocument,
     options,

--- a/dev-test/star-wars/__generated__/HeroDetails.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetails.tsx
@@ -61,9 +61,12 @@ export function useHeroDetailsLazyQuery(
   );
 }
 export function useHeroDetailsSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<HeroDetailsQuery, HeroDetailsQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HeroDetailsQuery, HeroDetailsQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HeroDetailsQuery, HeroDetailsQueryVariables>(
     HeroDetailsDocument,
     options,

--- a/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
+++ b/dev-test/star-wars/__generated__/HeroDetailsWithFragment.tsx
@@ -66,12 +66,15 @@ export function useHeroDetailsWithFragmentLazyQuery(
   );
 }
 export function useHeroDetailsWithFragmentSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroDetailsWithFragmentQuery,
-    HeroDetailsWithFragmentQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroDetailsWithFragmentQuery,
+        HeroDetailsWithFragmentQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroDetailsWithFragmentQuery,
     HeroDetailsWithFragmentQueryVariables

--- a/dev-test/star-wars/__generated__/HeroName.tsx
+++ b/dev-test/star-wars/__generated__/HeroName.tsx
@@ -49,9 +49,12 @@ export function useHeroNameLazyQuery(
   return Apollo.useLazyQuery<HeroNameQuery, HeroNameQueryVariables>(HeroNameDocument, options);
 }
 export function useHeroNameSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<HeroNameQuery, HeroNameQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HeroNameQuery, HeroNameQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HeroNameQuery, HeroNameQueryVariables>(HeroNameDocument, options);
 }
 export type HeroNameQueryHookResult = ReturnType<typeof useHeroNameQuery>;

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -74,12 +74,15 @@ export function useHeroNameConditionalInclusionLazyQuery(
   >(HeroNameConditionalInclusionDocument, options);
 }
 export function useHeroNameConditionalInclusionSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroNameConditionalInclusionQuery,
-    HeroNameConditionalInclusionQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroNameConditionalInclusionQuery,
+        HeroNameConditionalInclusionQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables
@@ -149,12 +152,15 @@ export function useHeroNameConditionalExclusionLazyQuery(
   >(HeroNameConditionalExclusionDocument, options);
 }
 export function useHeroNameConditionalExclusionSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroNameConditionalExclusionQuery,
-    HeroNameConditionalExclusionQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroNameConditionalExclusionQuery,
+        HeroNameConditionalExclusionQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables

--- a/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
+++ b/dev-test/star-wars/__generated__/HeroParentTypeDependentField.tsx
@@ -96,12 +96,15 @@ export function useHeroParentTypeDependentFieldLazyQuery(
   >(HeroParentTypeDependentFieldDocument, options);
 }
 export function useHeroParentTypeDependentFieldSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroParentTypeDependentFieldQuery,
-    HeroParentTypeDependentFieldQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroParentTypeDependentFieldQuery,
+        HeroParentTypeDependentFieldQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroParentTypeDependentFieldQuery,
     HeroParentTypeDependentFieldQueryVariables

--- a/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
+++ b/dev-test/star-wars/__generated__/HeroTypeDependentAliasedField.tsx
@@ -69,12 +69,15 @@ export function useHeroTypeDependentAliasedFieldLazyQuery(
   >(HeroTypeDependentAliasedFieldDocument, options);
 }
 export function useHeroTypeDependentAliasedFieldSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroTypeDependentAliasedFieldQuery,
-    HeroTypeDependentAliasedFieldQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroTypeDependentAliasedFieldQuery,
+        HeroTypeDependentAliasedFieldQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroTypeDependentAliasedFieldQuery,
     HeroTypeDependentAliasedFieldQueryVariables

--- a/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
+++ b/dev-test/star-wars/__generated__/HumanWithNullWeight.tsx
@@ -60,12 +60,12 @@ export function useHumanWithNullHeightLazyQuery(
   );
 }
 export function useHumanWithNullHeightSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HumanWithNullHeightQuery,
-    HumanWithNullHeightQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>(
     HumanWithNullHeightDocument,
     options,

--- a/dev-test/star-wars/__generated__/TwoHeroes.tsx
+++ b/dev-test/star-wars/__generated__/TwoHeroes.tsx
@@ -50,9 +50,12 @@ export function useTwoHeroesLazyQuery(
   return Apollo.useLazyQuery<TwoHeroesQuery, TwoHeroesQueryVariables>(TwoHeroesDocument, options);
 }
 export function useTwoHeroesSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<TwoHeroesQuery, TwoHeroesQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<TwoHeroesQuery, TwoHeroesQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<TwoHeroesQuery, TwoHeroesQueryVariables>(
     TwoHeroesDocument,
     options,

--- a/dev-test/star-wars/types.refetchFn.tsx
+++ b/dev-test/star-wars/types.refetchFn.tsx
@@ -363,12 +363,12 @@ export function useHeroAndFriendsNamesLazyQuery(
   );
 }
 export function useHeroAndFriendsNamesSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroAndFriendsNamesQuery,
-    HeroAndFriendsNamesQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HeroAndFriendsNamesQuery, HeroAndFriendsNamesQueryVariables>(
     HeroAndFriendsNamesDocument,
     options,
@@ -431,9 +431,12 @@ export function useHeroAppearsInLazyQuery(
   );
 }
 export function useHeroAppearsInSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<HeroAppearsInQuery, HeroAppearsInQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HeroAppearsInQuery, HeroAppearsInQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HeroAppearsInQuery, HeroAppearsInQueryVariables>(
     HeroAppearsInDocument,
     options,
@@ -495,9 +498,12 @@ export function useHeroDetailsLazyQuery(
   );
 }
 export function useHeroDetailsSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<HeroDetailsQuery, HeroDetailsQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HeroDetailsQuery, HeroDetailsQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HeroDetailsQuery, HeroDetailsQueryVariables>(
     HeroDetailsDocument,
     options,
@@ -563,12 +569,15 @@ export function useHeroDetailsWithFragmentLazyQuery(
   );
 }
 export function useHeroDetailsWithFragmentSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroDetailsWithFragmentQuery,
-    HeroDetailsWithFragmentQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroDetailsWithFragmentQuery,
+        HeroDetailsWithFragmentQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroDetailsWithFragmentQuery,
     HeroDetailsWithFragmentQueryVariables
@@ -629,9 +638,12 @@ export function useHeroNameLazyQuery(
   return Apollo.useLazyQuery<HeroNameQuery, HeroNameQueryVariables>(HeroNameDocument, options);
 }
 export function useHeroNameSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<HeroNameQuery, HeroNameQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HeroNameQuery, HeroNameQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HeroNameQuery, HeroNameQueryVariables>(HeroNameDocument, options);
 }
 export type HeroNameQueryHookResult = ReturnType<typeof useHeroNameQuery>;
@@ -692,12 +704,15 @@ export function useHeroNameConditionalInclusionLazyQuery(
   >(HeroNameConditionalInclusionDocument, options);
 }
 export function useHeroNameConditionalInclusionSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroNameConditionalInclusionQuery,
-    HeroNameConditionalInclusionQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroNameConditionalInclusionQuery,
+        HeroNameConditionalInclusionQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroNameConditionalInclusionQuery,
     HeroNameConditionalInclusionQueryVariables
@@ -772,12 +787,15 @@ export function useHeroNameConditionalExclusionLazyQuery(
   >(HeroNameConditionalExclusionDocument, options);
 }
 export function useHeroNameConditionalExclusionSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroNameConditionalExclusionQuery,
-    HeroNameConditionalExclusionQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroNameConditionalExclusionQuery,
+        HeroNameConditionalExclusionQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroNameConditionalExclusionQuery,
     HeroNameConditionalExclusionQueryVariables
@@ -866,12 +884,15 @@ export function useHeroParentTypeDependentFieldLazyQuery(
   >(HeroParentTypeDependentFieldDocument, options);
 }
 export function useHeroParentTypeDependentFieldSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroParentTypeDependentFieldQuery,
-    HeroParentTypeDependentFieldQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroParentTypeDependentFieldQuery,
+        HeroParentTypeDependentFieldQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroParentTypeDependentFieldQuery,
     HeroParentTypeDependentFieldQueryVariables
@@ -949,12 +970,15 @@ export function useHeroTypeDependentAliasedFieldLazyQuery(
   >(HeroTypeDependentAliasedFieldDocument, options);
 }
 export function useHeroTypeDependentAliasedFieldSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HeroTypeDependentAliasedFieldQuery,
-    HeroTypeDependentAliasedFieldQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        HeroTypeDependentAliasedFieldQuery,
+        HeroTypeDependentAliasedFieldQueryVariables
+      >,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
     HeroTypeDependentAliasedFieldQuery,
     HeroTypeDependentAliasedFieldQueryVariables
@@ -1027,12 +1051,12 @@ export function useHumanWithNullHeightLazyQuery(
   );
 }
 export function useHumanWithNullHeightSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    HumanWithNullHeightQuery,
-    HumanWithNullHeightQueryVariables
-  >,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<HumanWithNullHeightQuery, HumanWithNullHeightQueryVariables>(
     HumanWithNullHeightDocument,
     options,
@@ -1091,9 +1115,12 @@ export function useTwoHeroesLazyQuery(
   return Apollo.useLazyQuery<TwoHeroesQuery, TwoHeroesQueryVariables>(TwoHeroesDocument, options);
 }
 export function useTwoHeroesSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<TwoHeroesQuery, TwoHeroesQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<TwoHeroesQuery, TwoHeroesQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<TwoHeroesQuery, TwoHeroesQueryVariables>(
     TwoHeroesDocument,
     options,

--- a/dev-test/test-message/types.tsx
+++ b/dev-test/test-message/types.tsx
@@ -141,9 +141,12 @@ export function useGetMessagesLazyQuery(
   );
 }
 export function useGetMessagesSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<GetMessagesQuery, GetMessagesQueryVariables>,
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<GetMessagesQuery, GetMessagesQueryVariables>,
 ) {
-  const options = { ...defaultOptions, ...baseOptions };
+  const options =
+    baseOptions === Apollo.skipToken ? Apollo.skipToken : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<GetMessagesQuery, GetMessagesQueryVariables>(
     Operations.GetMessages,
     options,

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -436,8 +436,8 @@ export class ReactApolloVisitor extends ClientSideBaseVisitor<
         }) + this.config.hooksSuffix;
 
       hookFns.push(
-        `export function use${suspenseOperationName}(baseOptions?: ${this.getApolloReactHooksIdentifier()}.SuspenseQueryHookOptions<${operationResultType}, ${operationVariablesTypes}>) {
-          const options = {...defaultOptions, ...baseOptions}
+        `export function use${suspenseOperationName}(baseOptions?: ${this.getApolloReactHooksIdentifier()}.SkipToken | ${this.getApolloReactHooksIdentifier()}.SuspenseQueryHookOptions<${operationResultType}, ${operationVariablesTypes}>) {
+          const options = baseOptions === ${this.getApolloReactHooksIdentifier()}.skipToken ? ${this.getApolloReactHooksIdentifier()}.skipToken : {...defaultOptions, ...baseOptions}
           return ${this.getApolloReactHooksIdentifier()}.useSuspenseQuery<${operationResultType}, ${operationVariablesTypes}>(${this.getDocumentNodeVariable(
           node,
           documentVariableName,

--- a/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
+++ b/packages/plugins/typescript/react-apollo/tests/__snapshots__/react-apollo.spec.ts.snap
@@ -190,8 +190,8 @@ export function useGet_SomethingLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<Types.Get_SomethingQuery, Types.Get_SomethingQueryVariables>(Get_SomethingDocument, options);
         }
-export function useGet_SomethingSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<Types.Get_SomethingQuery, Types.Get_SomethingQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGet_SomethingSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.Get_SomethingQuery, Types.Get_SomethingQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<Types.Get_SomethingQuery, Types.Get_SomethingQueryVariables>(Get_SomethingDocument, options);
         }
 export type Get_SomethingQueryHookResult = ReturnType<typeof useGet_SomethingQuery>;
@@ -390,8 +390,8 @@ export function useGet_SomethingLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GQLGet_SomethingQuery, GQLGet_SomethingQueryVariables>(Get_SomethingDocument, options);
         }
-export function useGet_SomethingSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GQLGet_SomethingQuery, GQLGet_SomethingQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGet_SomethingSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GQLGet_SomethingQuery, GQLGet_SomethingQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GQLGet_SomethingQuery, GQLGet_SomethingQueryVariables>(Get_SomethingDocument, options);
         }
 export type Get_SomethingQueryHookResult = ReturnType<typeof useGet_SomethingQuery>;
@@ -590,8 +590,8 @@ export function useGetSomethingLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GetSomethingQuery, GetSomethingQueryVariables>(GetSomethingDocument, options);
         }
-export function useGetSomethingSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetSomethingQuery, GetSomethingQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGetSomethingSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetSomethingQuery, GetSomethingQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GetSomethingQuery, GetSomethingQueryVariables>(GetSomethingDocument, options);
         }
 export type GetSomethingQueryHookResult = ReturnType<typeof useGetSomethingQuery>;
@@ -790,8 +790,8 @@ export function useGetSomethingLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GetSomethingQuery, GetSomethingQueryVariables>(GetSomethingDocument, options);
         }
-export function useGetSomethingSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetSomethingQuery, GetSomethingQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGetSomethingSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetSomethingQuery, GetSomethingQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GetSomethingQuery, GetSomethingQueryVariables>(GetSomethingDocument, options);
         }
 export type GetSomethingQueryHookResult = ReturnType<typeof useGetSomethingQuery>;

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -1830,8 +1830,8 @@ export function useListenToCommentsSubscription(baseOptions?: Apollo.Subscriptio
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-      export function useFeedSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
+      export function useFeedSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>) {
+        const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
         return Apollo.useSuspenseQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
       }`);
       await validateTypeScript(content, schema, docs, {});
@@ -1898,8 +1898,8 @@ export function useListenToCommentsSubscription(baseOptions?: Apollo.Subscriptio
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-      export function useFeedSuspenseQueryMySuffix(baseOptions?: Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
+      export function useFeedSuspenseQueryMySuffix(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<FeedQuery, FeedQueryVariables>) {
+        const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
         return Apollo.useSuspenseQuery<FeedQuery, FeedQueryVariables>(FeedDocument, options);
       }`);
       await validateTypeScript(content, schema, docs, {});
@@ -2356,8 +2356,8 @@ export function useListenToCommentsSubscription(baseOptions?: Apollo.Subscriptio
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TestQuery, TestQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
+      export function useTestSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TestQuery, TestQueryVariables>) {
+        const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
         return Apollo.useSuspenseQuery<TestQuery, TestQueryVariables>(Operations.test, options);
       }
       `);
@@ -2614,8 +2614,8 @@ export function useListenToCommentsSubscription(baseOptions?: Apollo.Subscriptio
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestOneSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
+      export function useTestOneSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
+        const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
         return Apollo.useSuspenseQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, options);
       }
       `);
@@ -2742,8 +2742,8 @@ export function useListenToCommentsSubscription(baseOptions?: Apollo.Subscriptio
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TestQuery, TestQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
+      export function useTestSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TestQuery, TestQueryVariables>) {
+        const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
         return Apollo.useSuspenseQuery<TestQuery, TestQueryVariables>(Operations.test, options);
       }
       `);
@@ -3032,8 +3032,8 @@ export function useListenToCommentsSubscription(baseOptions?: Apollo.Subscriptio
       }
       `);
       expect(content.content).toBeSimilarStringTo(`
-      export function useTestOneSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
+      export function useTestOneSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TestOneQuery, TestOneQueryVariables>) {
+        const options = baseOptions === Apollo.skipToken ? Apollo.skipToken : {...defaultOptions, ...baseOptions}
         return Apollo.useSuspenseQuery<TestOneQuery, TestOneQueryVariables>(Operations.testOne, options);
       }
       `);


### PR DESCRIPTION
## Description

I would like to add the skipToken option to the React Apollo plugin. As mentioned in the issue, the skip option in Apollo Client is scheduled to be deprecated, and the use of the skipToken option is recommended instead.

Related #647 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] After updating the code, I conducted tests, linting, type checks, generation, and building locally.

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
