### PR TITLE
fix(docs): syntax in apollo-angular additionalDI code example. (#693)

### DIFF
--- a/packages/plugins/typescript/apollo-angular/src/config.ts
+++ b/packages/plugins/typescript/apollo-angular/src/config.ts
@@ -236,7 +236,7 @@ export interface ApolloAngularRawPluginConfig extends RawClientSideBasePluginCon
    *      'path/to/file': {
    *        plugins: ['apollo-angular'],
    *        config: {
-   *          additionalDI: ['testService: TestService', 'testService1': TestService1']
+   *          additionalDI: ['testService: TestService', 'testService1: TestService1']
    *        },
    *      },
    *    },


### PR DESCRIPTION
## Description

Corrected the syntax for the `additionalDI` configuration option of the apollo-angular plugin. 

#693 

## Type of change

This PR is a syntax correction for example code in the documentation for the configuration of the apollo-angular plugin.