### PR TITLE
fix(enum-array): support introspection result

### DIFF
--- a/.changeset/funny-doors-attend.md
+++ b/.changeset/funny-doors-attend.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-enum-array': minor
+---
+
+support introspection result

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ plugins:
   `@graphql-codegen/typescript-nhost`
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-type-graphql.svg)](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-type-graphql) -
   `@graphql-codegen/typescript-type-graphql`
+- [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-enum-array.svg)](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-enum-array) -
+  `@graphql-codegen/typescript-enum-array`
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Fcli.svg)](htjsdocs://badge.fury.io/js/%40graphql-codegen%2Fjsdoc) -
   `@graphql-codegen/jsdoc`
 - [![npm version](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-vue-urql.svg)](https://badge.fury.io/js/%40graphql-codegen%2Ftypescript-vue-urql) -

--- a/packages/plugins/typescript/enum-array/src/index.ts
+++ b/packages/plugins/typescript/enum-array/src/index.ts
@@ -1,4 +1,4 @@
-import { GraphQLEnumType, GraphQLSchema } from 'graphql';
+import { buildSchema, GraphQLEnumType, GraphQLSchema, printSchema } from 'graphql';
 import { PluginFunction, Types } from '@graphql-codegen/plugin-helpers';
 import { convertFactory } from '@graphql-codegen/visitor-plugin-common';
 import { EnumArrayPluginConfig } from './config.js';
@@ -54,7 +54,8 @@ export const plugin: PluginFunction<EnumArrayPluginConfig> = (
   _documents: Types.DocumentFile[],
   config: EnumArrayPluginConfig,
 ): Types.PluginOutput => {
-  const enums = getEnumTypeMap(schema);
+  // https://github.com/graphql/graphql-js/issues/1575#issuecomment-454978897
+  const enums = getEnumTypeMap(buildSchema(printSchema(schema)));
   const content = enums.map(e => buildArrayDefinition(e, config)).join('\n');
   const result: Types.PluginOutput = { content };
   if (config.importFrom) {


### PR DESCRIPTION
## Description

- added support to enum-array plugin for introspection result / remote schema
- added `@graphql-codegen/typescript-enum-array` to readme list

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

added test cases, also running a local fork at work with the same changes



## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

