### PR TITLE
feat(named-operations-object): add option to throw on duplicates

### DIFF
--- a/.changeset/tough-roses-divide.md
+++ b/.changeset/tough-roses-divide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/named-operations-object': minor
+---
+
+add option to throw on duplicate operation names

--- a/packages/plugins/typescript/named-operations-object/tests/plugin.spec.ts
+++ b/packages/plugins/typescript/named-operations-object/tests/plugin.spec.ts
@@ -223,4 +223,60 @@ describe('named-operations-object', () => {
       }
     }`);
   });
+
+  it('Should not throw on duplicate operations', async () => {
+    const result = await plugin(
+      null,
+      [
+        {
+          document: parse(/* GraphQL */ `
+            query myQuery {
+              id
+            }
+          `),
+        },
+        {
+          document: parse(/* GraphQL */ `
+            query myQuery {
+              id
+            }
+          `),
+        },
+      ],
+      {},
+    );
+
+    expect(result).toBeSimilarStringTo(`export const namedOperations = {
+      Query: {
+        myQuery: 'myQuery'
+      }
+    }`);
+  });
+
+  it('Should throw on duplicate operations when config.throwOnDuplicate is set', async () => {
+    expect(() =>
+      plugin(
+        null,
+        [
+          {
+            document: parse(/* GraphQL */ `
+              query myQuery {
+                id
+              }
+            `),
+          },
+          {
+            document: parse(/* GraphQL */ `
+              query myQuery {
+                id
+              }
+            `),
+          },
+        ],
+        {
+          throwOnDuplicate: true,
+        },
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(`"Duplicated operation name(s): myQuery"`);
+  });
 });


### PR DESCRIPTION
## Description

This adds an option to configure the `named-operations-object` plugin so that it throws an error when a duplicate operation definition is found.

Related #774

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

