### PR TITLE
fix(typescript-vue-urql): variable typing

### DIFF
--- a/.changeset/smooth-timers-peel.md
+++ b/.changeset/smooth-timers-peel.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-vue-urql': minor
+---
+
+Fix types for variables used in a query/subscription

--- a/packages/plugins/typescript/vue-urql/src/visitor.ts
+++ b/packages/plugins/typescript/vue-urql/src/visitor.ts
@@ -92,14 +92,14 @@ export function use${operationName}() {
 
     if (operationType === 'Subscription') {
       return `
-export function use${operationName}<R = ${operationResultType}>(options: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes}>, 'query'>, handler?: Urql.SubscriptionHandlerArg<${operationResultType}, R>) {
-  return Urql.use${operationType}<${operationResultType}, R, ${operationVariablesTypes}>({ query: ${documentVariableName}, ...options }, handler);
+export function use${operationName}<R = ${operationResultType}>(options?: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes} | undefined>, 'query'>, handler?: Urql.SubscriptionHandlerArg<${operationResultType}, R>) {
+  return Urql.use${operationType}<${operationResultType}, R, ${operationVariablesTypes} | undefined>({ query: ${documentVariableName}, variables: undefined, ...options }, handler);
 };`;
     }
 
     return `
-export function use${operationName}(options: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes}>, 'query'>) {
-  return Urql.use${operationType}<${operationResultType}, ${operationVariablesTypes}>({ query: ${documentVariableName}, ...options });
+export function use${operationName}(options?: Omit<Urql.Use${operationType}Args<never, ${operationVariablesTypes} | undefined>, 'query'>) {
+  return Urql.use${operationType}<${operationResultType}, ${operationVariablesTypes} | undefined>({ query: ${documentVariableName}, variables: undefined, ...options });
 };`;
   }
 

--- a/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
+++ b/packages/plugins/typescript/vue-urql/tests/__snapshots__/urql.spec.ts.snap
@@ -13,8 +13,8 @@ export const ListenToCommentsDocument = gql\`
 }
     \`;
 
-export function useListenToCommentsSubscription<R = ListenToCommentsSubscription>(options: Omit<Urql.UseSubscriptionArgs<never, ListenToCommentsSubscriptionVariables>, 'query'>, handler?: Urql.SubscriptionHandlerArg<ListenToCommentsSubscription, R>) {
-  return Urql.useSubscription<ListenToCommentsSubscription, R, ListenToCommentsSubscriptionVariables>({ query: ListenToCommentsDocument, ...options }, handler);
+export function useListenToCommentsSubscription<R = ListenToCommentsSubscription>(options?: Omit<Urql.UseSubscriptionArgs<never, ListenToCommentsSubscriptionVariables | undefined>, 'query'>, handler?: Urql.SubscriptionHandlerArg<ListenToCommentsSubscription, R>) {
+  return Urql.useSubscription<ListenToCommentsSubscription, R, ListenToCommentsSubscriptionVariables | undefined>({ query: ListenToCommentsDocument, variables: undefined, ...options }, handler);
 };"
 `;
 
@@ -24,7 +24,7 @@ import * as Urql from '@urql/vue';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 
-export function useTestQuery(options: Omit<Urql.UseQueryArgs<never, Operations.TestQueryVariables>, 'query'>) {
-  return Urql.useQuery<Operations.TestQuery, Operations.TestQueryVariables>({ query: Operations.TestDocument, ...options });
+export function useTestQuery(options?: Omit<Urql.UseQueryArgs<never, Operations.TestQueryVariables | undefined>, 'query'>) {
+  return Urql.useQuery<Operations.TestQuery, Operations.TestQueryVariables | undefined>({ query: Operations.TestDocument, variables: undefined, ...options });
 };"
 `;

--- a/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
+++ b/packages/plugins/typescript/vue-urql/tests/urql.spec.ts
@@ -477,8 +477,8 @@ query MyFeed {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-export function useFeedQuery(options: Omit<Urql.UseQueryArgs<never, FeedQueryVariables>, 'query'>) {
-  return Urql.useQuery<FeedQuery, FeedQueryVariables>({ query: FeedDocument, ...options });
+export function useFeedQuery(options?: Omit<Urql.UseQueryArgs<never, FeedQueryVariables | undefined>, 'query'>) {
+  return Urql.useQuery<FeedQuery, FeedQueryVariables | undefined>({ query: FeedDocument, variables: undefined, ...options });
 };`);
 
       expect(content.content).toBeSimilarStringTo(`
@@ -524,8 +524,8 @@ export function useSubmitRepositoryMutation() {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-      export function useListenToCommentsSubscription<R = ListenToCommentsSubscription>(options: Omit<Urql.UseSubscriptionArgs<never, ListenToCommentsSubscriptionVariables>, 'query'>, handler?: Urql.SubscriptionHandlerArg<ListenToCommentsSubscription, R>) {
-        return Urql.useSubscription<ListenToCommentsSubscription, R, ListenToCommentsSubscriptionVariables>({ query: ListenToCommentsDocument, ...options }, handler);
+      export function useListenToCommentsSubscription<R = ListenToCommentsSubscription>(options?: Omit<Urql.UseSubscriptionArgs<never, ListenToCommentsSubscriptionVariables | undefined>, 'query'>, handler?: Urql.SubscriptionHandlerArg<ListenToCommentsSubscription, R>) {
+        return Urql.useSubscription<ListenToCommentsSubscription, R, ListenToCommentsSubscriptionVariables | undefined>({ query: ListenToCommentsDocument, variables: undefined, ...options }, handler);
       };`);
       await validateTypeScript(content, schema, docs, {});
       expect(mergeOutputs([content])).toMatchSnapshot();


### PR DESCRIPTION
## Description

Generation template for vue urql query/subscription was changed in https://github.com/dotansimha/graphql-code-generator-community/pull/329.
That was necessary due to [changes](https://github.com/urql-graphql/urql/pull/3022) in `urql-vue` lib, which caused a number of regressions. Currently, all of them was [fixed](https://github.com/urql-graphql/urql/pulls?q=is%3Apr+is%3Aclosed+vue) and finally [released](https://github.com/urql-graphql/urql/releases/tag/%40urql%2Fvue%401.4.0) with `urql-vue@1.4.0`

This PR basically reverts https://github.com/dotansimha/graphql-code-generator-community/pull/329 and and fits `urql-vue@1.4.0` changes.

Related #328
Related #403
Related https://github.com/dotansimha/graphql-code-generator/issues/9421

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Was built and used in live internal project

**Test Environment**:

- OS: MacOS
- @graphql-codegen/typescript-vue-urql:
- NodeJS: 20

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

https://github.com/urql-graphql/urql/pull/3605