### PR TITLE
fix(deps): move `graphql-tag` to devDeps from peerDeps for typescript-react-apollo

### DIFF
--- a/.changeset/few-apes-march.md
+++ b/.changeset/few-apes-march.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-apollo': patch
+---
+
+Move `graphql-tag` to `devDependencies` from `peerDependencies`.

--- a/packages/plugins/typescript/react-apollo/package.json
+++ b/packages/plugins/typescript/react-apollo/package.json
@@ -37,8 +37,7 @@
     "test": "jest --no-watchman --config ../../../../jest.config.js --forceExit"
   },
   "peerDependencies": {
-    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-tag": "^2.0.0"
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^3.0.0",
@@ -48,7 +47,8 @@
     "tslib": "~2.6.0"
   },
   "devDependencies": {
-    "@graphql-codegen/testing": "1.18.0"
+    "@graphql-codegen/testing": "1.18.0",
+    "graphql-tag": "^2.12.6"
   },
   "publishConfig": {
     "directory": "dist",


### PR DESCRIPTION
## Description

`graphql-tag` is only used in .spec files within the `typescript-react-apollo` package. Similar to `typescript-apollo-angular`, this commit moves `graphql-tag` to devDependencies so package consumers aren't required to install it to remove warning:

```
warning " > @graphql-codegen/typescript-react-apollo@4.3.0" has unmet peer dependency "graphql-tag@^2.0.0".
```

## Related (issue)

Closes https://github.com/dotansimha/graphql-code-generator-community/issues/471

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Checked that dev/build environment tasks still work as expected.
- Checked local install of this updated package in another project repo to ensure consumers aren't broken and `yarn install` warning is no longer displayed.

**Test Environment**:

- OS: macOS Sonoma 14.5
- `@graphql-codegen/typescript-react-apollo`: 4.3.0
- NodeJS: v20.11.1

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules