### PR TITLE
Fix/c sharp operations member name casing

### DIFF
--- a/.changeset/quick-insects-matter.md
+++ b/.changeset/quick-insects-matter.md
@@ -1,0 +1,9 @@
+---
+'@graphql-codegen/c-sharp-operations': minor
+'@graphql-codegen/c-sharp-common': minor
+'@graphql-codegen/c-sharp': minor
+---
+
+Added support for the new configuration option `memberNameConvention` to the c-sharp-operations
+plugin. Now both C# plugins can generate C# code with standard member casing. The default is still
+camel case, to avoid generating code that breaks user's existing code base.

--- a/packages/plugins/c-sharp/c-sharp-common/src/index.ts
+++ b/packages/plugins/c-sharp/c-sharp-common/src/index.ts
@@ -3,3 +3,4 @@ export * from './scalars.js';
 export * from './utils.js';
 export * from './c-sharp-field-types.js';
 export * from './keywords.js';
+export * from './member-naming.js';

--- a/packages/plugins/c-sharp/c-sharp-common/src/member-naming.ts
+++ b/packages/plugins/c-sharp/c-sharp-common/src/member-naming.ts
@@ -1,12 +1,25 @@
 import { camelCase, pascalCase } from 'change-case-all';
 import { NameNode } from 'graphql';
-import { CSharpResolversPluginRawConfig } from '../../c-sharp/src/config';
+
+/**
+ * @description Configuration for member naming conventions.
+ */
+export type MemberNameConventionConfig = {
+  memberNameConvention?: 'camelCase' | 'pascalCase';
+};
 
 type MemberNamingFunctionInput = string | NameNode;
-
+/**
+ * @description Type func signature of a function is responsible for transforming the name of a member (property, method) to a valid C# identifier.
+ */
 export type MemberNamingFn = (nameOrNameNode: MemberNamingFunctionInput) => string;
 
-export function getMemberNamingFunction(rawConfig: CSharpResolversPluginRawConfig): MemberNamingFn {
+/**
+ * @description Get the member naming function based on the provided configuration.
+ * @param rawConfig Config to decide which concrete naming function to return. Fallback to camelCase if not provided.
+ * @returns
+ */
+export function getMemberNamingFunction(rawConfig: MemberNameConventionConfig): MemberNamingFn {
   switch (rawConfig.memberNameConvention) {
     case 'camelCase':
       return (input: MemberNamingFunctionInput) =>

--- a/packages/plugins/c-sharp/c-sharp-common/src/member-naming.ts
+++ b/packages/plugins/c-sharp/c-sharp-common/src/member-naming.ts
@@ -1,6 +1,6 @@
 import { camelCase, pascalCase } from 'change-case-all';
 import { NameNode } from 'graphql';
-import { CSharpResolversPluginRawConfig } from './config';
+import { CSharpResolversPluginRawConfig } from '../../c-sharp/src/config';
 
 type MemberNamingFunctionInput = string | NameNode;
 

--- a/packages/plugins/c-sharp/c-sharp-operations/src/config.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/config.ts
@@ -1,9 +1,12 @@
+import { MemberNameConventionConfig } from '@graphql-codegen/c-sharp-common';
 import { RawClientSideBasePluginConfig } from '@graphql-codegen/visitor-plugin-common';
 
 /**
  * @description This plugin generates C# `class` based on your GraphQL operations.
  */
-export interface CSharpOperationsRawPluginConfig extends RawClientSideBasePluginConfig {
+export interface CSharpOperationsRawPluginConfig
+  extends RawClientSideBasePluginConfig,
+    MemberNameConventionConfig {
   /**
    * @default GraphQLCodeGen
    * @description Allow you to customize the namespace name.

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -327,10 +327,13 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
             responseType.listType,
             'System.Collections.Generic.List',
           );
+          const propertyName = convertSafeName(
+            this._parsedConfig.memberNamingFunction(node.name.value),
+          );
           return indentMultiline(
             [
               `[JsonProperty("${node.name.value}")]`,
-              `public ${responseTypeName} ${convertSafeName(node.name.value)} { get; set; }`,
+              `public ${responseTypeName} ${propertyName} { get; set; }`,
             ].join('\n') + '\n',
           );
         }
@@ -363,11 +366,14 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
                 })
                 .join('\n'),
           ).string;
+        const propertyName = convertSafeName(
+          this._parsedConfig.memberNamingFunction(node.name.value),
+        );
         return indentMultiline(
           [
             innerClassDefinition,
             `[JsonProperty("${node.name.value}")]`,
-            `public ${selectionTypeName} ${convertSafeName(node.name.value)} { get; set; }`,
+            `public ${selectionTypeName} ${propertyName} { get; set; }`,
           ].join('\n') + '\n',
         );
       }
@@ -416,10 +422,13 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
                 inputType.listType,
                 'System.Collections.Generic.List',
               );
+              const propertyName = convertSafeName(
+                this._parsedConfig.memberNamingFunction(v.variable.name.value),
+              );
               return indentMultiline(
                 [
                   `[JsonProperty("${v.variable.name.value}")]`,
-                  `public ${inputTypeName} ${convertSafeName(v.variable.name.value)} { get; set; }`,
+                  `public ${inputTypeName} ${propertyName} { get; set; }`,
                 ].join('\n') + '\n',
               );
             })
@@ -595,10 +604,13 @@ ${this._getOperationMethod(node)}
                 inputType.listType,
                 'System.Collections.Generic.List',
               );
+              const propertyName = convertSafeName(
+                this._parsedConfig.memberNamingFunction(f.name.value),
+              );
               return indentMultiline(
                 [
                   `[JsonProperty("${f.name.value}")]`,
-                  `public ${inputTypeName} ${convertSafeName(f.name.value)} { get; set; }`,
+                  `public ${inputTypeName} ${propertyName} { get; set; }`,
                 ].join('\n') + '\n',
               );
             })

--- a/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
@@ -1265,6 +1265,42 @@ describe('C# Operations', () => {
     });
   });
 
+  describe('MemberNamingConfig', () => {
+    it('Should generate enums with pascal case values', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          myQuery: MyEnum!
+        }
+        enum MyEnum {
+          Value1
+          value2
+          anotherValue
+          LastValue
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query GetMyQuery {
+          myQuery
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        { typesafeOperation: true, memberNameConvention: 'pascalCase' },
+        { outputFile: '' },
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public enum MyEnum {
+           Value1,
+           Value2,
+           AnotherValue,
+           LastValue
+        }
+        `);
+    });
+  });
+
   describe('Issues', () => {
     it('#4221 - suffix query mutation subscription', async () => {
       const schema = buildSchema(/* GraphQL */ `

--- a/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
@@ -1299,6 +1299,80 @@ describe('C# Operations', () => {
         }
         `);
     });
+
+    it('Should generate input classes with pascal case property names', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          myQuery(filter: MyQueryFilter): [MyData]
+        }
+        type MyData {
+          id: ID!
+          name: String!
+        }
+        input MyQueryFilter {
+          nameFilter: String!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query GetMyQuery {
+          myQuery
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        { typesafeOperation: true, memberNameConvention: 'pascalCase' },
+        { outputFile: '' },
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public class MyQueryFilter {
+          [JsonProperty("nameFilter")]
+          public string NameFilter { get; set; }
+        }
+        `);
+    });
+
+    it('Should generate output classes with pascal case property names', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          myQuery: [MyData]
+        }
+        type MyData {
+          id: ID!
+          firstName: String!
+          lastName: String!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        query GetMyQuery {
+          myQuery {
+            id
+            firstName
+            lastName
+          }
+        }
+      `);
+
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        { typesafeOperation: true, memberNameConvention: 'pascalCase' },
+        { outputFile: '' },
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public class MyDataSelection {
+          [JsonProperty("id")]
+          public string Id { get; set; }
+
+          [JsonProperty("firstName")]
+          public string FirstName { get; set; }
+
+          [JsonProperty("lastName")]
+          public string LastName { get; set; }
+        }
+        `);
+    });
   });
 
   describe('Issues', () => {

--- a/packages/plugins/c-sharp/c-sharp/src/config.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/config.ts
@@ -1,10 +1,11 @@
+import { MemberNameConventionConfig } from '@graphql-codegen/c-sharp-common';
 import { EnumValuesMap, RawConfig } from '@graphql-codegen/visitor-plugin-common';
 import { JsonAttributesSource } from './json-attributes.js';
 
 /**
  * @description This plugin generates C# `class` identifier for your schema types.
  */
-export interface CSharpResolversPluginRawConfig extends RawConfig {
+export interface CSharpResolversPluginRawConfig extends RawConfig, MemberNameConventionConfig {
   /**
    * @description Overrides the default value of enum values declared in your GraphQL schema.
    * @exampleMarkdown
@@ -110,21 +111,4 @@ export interface CSharpResolversPluginRawConfig extends RawConfig {
    * ```
    */
   jsonAttributesSource?: JsonAttributesSource;
-
-  /**
-   * @default camelCase
-   * Supported: camelCase, pascalCase
-   * @description Allows you to customize the naming convention for interface/class/record members.
-   *
-   * @exampleMarkdown
-   * ```yaml
-   * generates:
-   *   src/main/c-sharp/my-org/my-app/MyTypes.cs:
-   *     plugins:
-   *       - c-sharp
-   *     config:
-   *       fieldNameConvention: pascalCase
-   * ```
-   */
-  memberNameConvention?: 'camelCase' | 'pascalCase';
 }

--- a/packages/plugins/c-sharp/c-sharp/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp/src/visitor.ts
@@ -23,7 +23,9 @@ import {
   CSharpFieldType,
   getListInnerTypeNode,
   getListTypeField,
+  getMemberNamingFunction,
   isValueType,
+  MemberNamingFn,
   transformComment,
   wrapFieldType,
 } from '@graphql-codegen/c-sharp-common';
@@ -42,7 +44,6 @@ import {
   JsonAttributesSource,
   JsonAttributesSourceConfiguration,
 } from './json-attributes.js';
-import { getMemberNamingFunction, MemberNamingFn } from './member-naming.js';
 
 export interface CSharpResolverParsedConfig extends ParsedConfig {
   namespaceName: string;


### PR DESCRIPTION
## Description

Added support for the new configuration option `memberNameConvention` to the c-sharp-operations plugin. Now both C# plugins can generate C# code with standard member casing.
The default is still camel case, to avoid generating code that breaks user's existing code base.

Related #798 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

The existing tests of the `c-sharp-operations` plugin were extended with a new group of tests called `MemberNamingConfig`. Those tests cover non-default `memberNameConvention` values, currently only pascal case.

**Test Environment**:

- OS: macOS
- `@graphql-codegen/c-sharp-operations`: 3.0.0
- NodeJS: v16.13.2

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules