### PR TITLE
fix: add empty object in place of variables for more consistent keys

### DIFF
--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -511,7 +511,7 @@ export const useCurrentUserForProfileQuery = <TData = CurrentUserForProfileQuery
   options?: UseQueryOptions<CurrentUserForProfileQuery, TError, TData>,
 ) => {
   return useQuery<CurrentUserForProfileQuery, TError, TData>(
-    variables === undefined ? ['CurrentUserForProfile'] : ['CurrentUserForProfile', variables],
+    variables === undefined ? ['CurrentUserForProfile', {}] : ['CurrentUserForProfile', variables],
     fetcher<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(
       dataSource.endpoint,
       dataSource.fetchParams || {},
@@ -532,7 +532,7 @@ export const useInfiniteCurrentUserForProfileQuery = <
 ) => {
   return useInfiniteQuery<CurrentUserForProfileQuery, TError, TData>(
     variables === undefined
-      ? ['CurrentUserForProfile.infinite']
+      ? ['CurrentUserForProfile.infinite', {}]
       : ['CurrentUserForProfile.infinite', variables],
     metaData =>
       fetcher<CurrentUserForProfileQuery, CurrentUserForProfileQueryVariables>(

--- a/packages/plugins/typescript/react-query/src/fetcher.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher.ts
@@ -226,7 +226,7 @@ export abstract class FetcherRenderer {
     const identifier = isSuspense ? 'infiniteSuspense' : 'infinite';
     if (config.hasRequiredVariables)
       return `['${config.node.name.value}.${identifier}', variables]`;
-    return `variables === undefined ? ['${config.node.name.value}.${identifier}'] : ['${config.node.name.value}.${identifier}', variables]`;
+    return `variables === undefined ? ['${config.node.name.value}.${identifier}', {}] : ['${config.node.name.value}.${identifier}', variables]`;
   }
 
   public generateInfiniteQueryOutput(config: GenerateConfig, isSuspense = false) {
@@ -245,7 +245,7 @@ export abstract class FetcherRenderer {
   public generateQueryKey(config: GenerateConfig, isSuspense: boolean): string {
     const identifier = isSuspense ? `${config.node.name.value}Suspense` : config.node.name.value;
     if (config.hasRequiredVariables) return `['${identifier}', variables]`;
-    return `variables === undefined ? ['${identifier}'] : ['${identifier}', variables]`;
+    return `variables === undefined ? ['${identifier}', {}] : ['${identifier}', variables]`;
   }
 
   public generateQueryOutput(config: GenerateConfig, isSuspense = false) {

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -29,12 +29,12 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     )};
 
-useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];
+useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test', {}] : ['test', variables];
 
 export const TestDocument = \`
     mutation test($name: String) {
@@ -89,12 +89,12 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     )};
 
-useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];
+useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test', {}] : ['test', variables];
 
 export const useInfiniteTestQuery = <
       TData = TestQuery,
@@ -106,12 +106,12 @@ export const useInfiniteTestQuery = <
     ) => {
     
     return useInfiniteQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables],
       (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     )};
 
-useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite'] : ['test.infinite', variables];
+useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables];
 
 export const TestDocument = \`
     mutation test($name: String) {
@@ -166,7 +166,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     )};
@@ -226,7 +226,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     )};
@@ -243,7 +243,7 @@ export const useInfiniteTestQuery = <
     ) => {
     
     return useInfiniteQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables],
       (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     )};
@@ -302,7 +302,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument).bind(null, variables),
       options
     )};
@@ -316,7 +316,7 @@ export const useInfiniteTestQuery = <
     ) => {
     const query = useCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument)
     return useInfiniteQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables],
       (metaData) => query({...variables, ...(metaData.pageParam ?? {})}),
       options
     )};
@@ -377,7 +377,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     )};
@@ -391,7 +391,7 @@ export const useInfiniteTestQuery = <
     ) => {
     
     return useInfiniteQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables],
       (metaData) => myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     )};
@@ -452,7 +452,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       myCustomFetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     )};
@@ -514,7 +514,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     )};
@@ -599,7 +599,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, variables, headers),
       options
     )};
@@ -615,7 +615,7 @@ export const useInfiniteTestQuery = <
     ) => {
     
     return useInfiniteQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables],
       (metaData) => fetcher<TTestQuery, TTestQueryVariables>(client, TestDocument, {...variables, ...(metaData.pageParam ?? {})}, headers)(),
       options
     )};
@@ -690,7 +690,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables, headers),
       options
     )};
@@ -764,7 +764,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     )};
@@ -844,7 +844,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     )};
@@ -924,7 +924,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     )};
@@ -1003,7 +1003,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     )};
@@ -1082,7 +1082,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TTestQuery, TTestQueryVariables>(TestDocument, variables),
       options
     )};
@@ -1096,7 +1096,7 @@ export const useInfiniteTestQuery = <
     ) => {
     
     return useInfiniteQuery<TTestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables],
       (metaData) => fetcher<TTestQuery, TTestQueryVariables>(TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     )};
@@ -1202,7 +1202,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<Types.TestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<Types.TestQuery, Types.TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     )};
@@ -1261,7 +1261,7 @@ export const useTestQuery = <
     
     return useQuery<Types.TestQuery, TError, TData>(
       {
-    queryKey: variables === undefined ? ['test'] : ['test', variables],
+    queryKey: variables === undefined ? ['test', {}] : ['test', variables],
     queryFn: fetcher<Types.TestQuery, Types.TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
     ...options
   }
@@ -1322,7 +1322,7 @@ export const useTestQuery = <
     ) => {
     
     return useQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test'] : ['test', variables],
+      variables === undefined ? ['test', {}] : ['test', variables],
       fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
       options
     )};
@@ -1337,7 +1337,7 @@ export const useInfiniteTestQuery = <
     ) => {
     
     return useInfiniteQuery<TestQuery, TError, TData>(
-      variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables],
       (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       options
     )};
@@ -1422,7 +1422,7 @@ export const useTestQuery = <
     
     return useQuery<TestQuery, TError, TData>(
       {
-    queryKey: variables === undefined ? ['test'] : ['test', variables],
+    queryKey: variables === undefined ? ['test', {}] : ['test', variables],
     queryFn: fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
     ...options
   }
@@ -1439,7 +1439,7 @@ export const useSuspenseTestQuery = <
     
     return useSuspenseQuery<TestQuery, TError, TData>(
       {
-    queryKey: variables === undefined ? ['testSuspense'] : ['testSuspense', variables],
+    queryKey: variables === undefined ? ['testSuspense', {}] : ['testSuspense', variables],
     queryFn: fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, variables),
     ...options
   }
@@ -1458,7 +1458,7 @@ export const useInfiniteTestQuery = <
       (() => {
     const { queryKey: optionsQueryKey, ...restOptions } = options;
     return {
-      queryKey: optionsQueryKey ?? variables === undefined ? ['test.infinite'] : ['test.infinite', variables],
+      queryKey: optionsQueryKey ?? variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables],
       queryFn: (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       ...restOptions
     }
@@ -1478,7 +1478,7 @@ export const useSuspenseInfiniteTestQuery = <
       (() => {
     const { queryKey: optionsQueryKey, ...restOptions } = options;
     return {
-      queryKey: optionsQueryKey ?? variables === undefined ? ['test.infiniteSuspense'] : ['test.infiniteSuspense', variables],
+      queryKey: optionsQueryKey ?? variables === undefined ? ['test.infiniteSuspense', {}] : ['test.infiniteSuspense', variables],
       queryFn: (metaData) => fetcher<TestQuery, TestQueryVariables>(dataSource.endpoint, dataSource.fetchParams || {}, TestDocument, {...variables, ...(metaData.pageParam ?? {})})(),
       ...restOptions
     }

--- a/packages/plugins/typescript/react-query/tests/react-query.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.spec.ts
@@ -965,7 +965,7 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toMatchSnapshot();
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];`,
+        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test', {}] : ['test', variables];`,
       );
     });
   });
@@ -980,10 +980,10 @@ describe('React-Query', () => {
       const out = (await plugin(schema, docs, config)) as Types.ComplexPluginOutput;
       expect(out.content).toMatchSnapshot();
       expect(out.content).toBeSimilarStringTo(
-        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test'] : ['test', variables];`,
+        `useTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test', {}] : ['test', variables];`,
       );
       expect(out.content).toBeSimilarStringTo(
-        `useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite'] : ['test.infinite', variables];`,
+        `useInfiniteTestQuery.getKey = (variables?: TestQueryVariables) => variables === undefined ? ['test.infinite', {}] : ['test.infinite', variables];`,
       );
     });
   });


### PR DESCRIPTION
## Description

Addresses potential issues stemming from mismatched generated keys.

Related https://github.com/dotansimha/graphql-code-generator-community/issues/866

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

NOTE: Does have a fairly minor breaking change in case clients were hard-coding keys (not using generated helpers) and specifying "exact" react-query key matching

## How Has This Been Tested?

Automated tests have been updated to accommodate this change

**Test Environment**:

- OS: macOS
- `@graphql-codegen/typescript-react-query`: 6.1.0

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

