### PR TITLE
Add persisted operations to near-operation-file

### DIFF
--- a/packages/presets/near-operation-file/package.json
+++ b/packages/presets/near-operation-file/package.json
@@ -43,6 +43,7 @@
     "@graphql-codegen/add": "^3.2.1",
     "@graphql-codegen/plugin-helpers": "^3.0.0",
     "@graphql-codegen/visitor-plugin-common": "2.13.1",
+    "@graphql-tools/documents": "^1.0.0",
     "@graphql-tools/utils": "^10.0.0",
     "parse-filepath": "^1.0.2",
     "tslib": "~2.6.0"

--- a/packages/presets/near-operation-file/src/persisted-documents.ts
+++ b/packages/presets/near-operation-file/src/persisted-documents.ts
@@ -1,0 +1,44 @@
+import { printExecutableGraphQLDocument } from '@graphql-tools/documents';
+import * as crypto from 'crypto';
+import { Kind, visit, type DocumentNode } from 'graphql';
+
+/**
+ * This function generates a hash from a document node.
+ */
+export function generateDocumentHash(
+  operation: string,
+  algorithm: 'sha1' | 'sha256' | (string & {}) | ((operation: string) => string)
+): string {
+  if (typeof algorithm === 'function') {
+    return algorithm(operation);
+  }
+  const shasum = crypto.createHash(algorithm);
+  shasum.update(operation);
+  return shasum.digest('hex');
+}
+
+/**
+ * Normalizes and prints a document node.
+ */
+export function normalizeAndPrintDocumentNode(documentNode: DocumentNode): string {
+  /**
+   * This removes all client specific directives/fields from the document
+   * that the server does not know about.
+   * In a future version this should be more configurable.
+   * If you look at this and want to customize it.
+   * Send a PR :)
+   */
+  const sanitizedDocument = visit(documentNode, {
+    [Kind.FIELD](field) {
+      if (field.directives?.some(directive => directive.name.value === 'client')) {
+        return null;
+      }
+    },
+    [Kind.DIRECTIVE](directive) {
+      if (directive.name.value === 'connection') {
+        return null;
+      }
+    },
+  });
+  return printExecutableGraphQLDocument(sanitizedDocument);
+}


### PR DESCRIPTION
## Description

Adds persisted operation support to `near-operation-file`.  Since I've no idea what I'm doing, I had Cline (Anthropic AI), copy functionality from `client-preset` and this is what it came up with.

Related:
- #496 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Hoping someone else knows how to finish/test this PR.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Sorry, I don't know much about codegen plugins.  Just hoping this PR will kick start some community progress.  I will update this PR if/as I make any more progress.

At a minimum, this code could be used as a reference for issue #496 