### PR TITLE
Replace OperationStore import with OperationResultStore from urql

### DIFF
--- a/packages/plugins/typescript/urql-svelte-operations-store/src/index.ts
+++ b/packages/plugins/typescript/urql-svelte-operations-store/src/index.ts
@@ -41,7 +41,7 @@ export const plugin: PluginFunction<Record<string, any>, Types.ComplexPluginOutp
           suffix: operationTypeSuffix + operationResultSuffix,
         });
 
-        return `export type ${storeTypeName} = OperationStore<${operationResultType}, ${operationVariablesTypes}>;`;
+        return `export type ${storeTypeName} = OperationResultStore<${operationResultType}, ${operationVariablesTypes}>;`;
       }
 
       return null;
@@ -49,7 +49,7 @@ export const plugin: PluginFunction<Record<string, any>, Types.ComplexPluginOutp
     .filter(Boolean);
 
   return {
-    prepend: [`import type { OperationStore } from '@urql/svelte';`],
+    prepend: [`import type { OperationResultStore } from '@urql/svelte';`],
     content: out.filter(Boolean).join('\n'),
   };
 };


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description
Updated `@graphql-codegen/urql-svelte-operations-store` to import `OperationResultStore` in place of `OperationStore` from `@urql/svelte`

Related # (issue)
['"@urql/svelte"' has no exported member named 'OperationStore'. Did you mean 'OperationType'?](https://github.com/dotansimha/graphql-code-generator-community/issues/904
)
## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?


- [ ] `pnpm build`

**Test Environment**:

- OS: Linux
- `@graphql-codegen/...`: 5.0.3
- NodeJS: 20.11.1

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

