### PR TITLE
fix(near-operation-file-preset): fragment generation without suffix

### DIFF
--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -66,7 +66,7 @@ function buildFragmentRegistry(
         fragmentImports.push({
           name: baseVisitor.convertName(name, {
             useTypesPrefix: true,
-            suffix: `_${typeName}_${fragmentSuffix}`,
+            suffix: `_${typeName}${fragmentSuffix ? `_${fragmentSuffix}` : ''}`,
           }),
           kind: 'type',
         });


### PR DESCRIPTION
## Description

I found that all fragment types were generated with `_` suffix in the imports even with `omitOperationSuffix: false`. However, in the generated usage of the type, this suffix did not exist (works correctly with `omitOperationSuffix`).

In the past, `near-operation-file-preset` used to work with the following versions:
```
    "@graphql-codegen/cli": "5.0.0",
    "@graphql-codegen/typescript": "4.0.9",
    "@graphql-codegen/typescript-operations": "4.0.1",
```

With this fix the preset also works with the latest versions.

Related https://github.com/dotansimha/graphql-code-generator-community/issues/812

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I created a local patch of this library and continue to use the preset with the latest versions of other packages.

**Test Environment**:

- OS: macOS 15.1.1
- `@graphql-codegen/cli`: 5.0.3
- `@graphql-codegen/typescript`: 4.1.2
- `@graphql-codegen/typescript-operations`: 4.4.0
- NodeJS: v20.18.0

## Checklist:

- [ x I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
