### PR TITLE
fix: Query keys should be shared between suspense and not suspense

### DIFF
--- a/packages/plugins/typescript/react-query/src/fetcher.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher.ts
@@ -99,7 +99,7 @@ export abstract class FetcherRenderer {
     ${implHookOuter}
     return ${infiniteQuery.getHook()}<${operationResultType}, TError, TData>(
       ${this.generateInfiniteQueryFormattedParameters(
-        this.generateInfiniteQueryKey(config, isSuspense),
+        this.generateInfiniteQueryKey(config),
         implFetcher,
       )}
     )};`;
@@ -136,7 +136,7 @@ export abstract class FetcherRenderer {
     ${implHookOuter}
     return ${query.getHook()}<${operationResultType}, TError, TData>(
       ${this.generateQueryFormattedParameters(
-        this.generateQueryKey(config, isSuspense),
+        this.generateQueryKey(config),
         implFetcher,
       )}
     )};`;
@@ -222,8 +222,8 @@ export abstract class FetcherRenderer {
     return `options: Omit<${infiniteQuery.getOptions()}<${operationResultType}, TError, TData>, 'queryKey'> & { queryKey?: ${infiniteQuery.getOptions()}<${operationResultType}, TError, TData>['queryKey'] }`;
   }
 
-  public generateInfiniteQueryKey(config: GenerateConfig, isSuspense: boolean): string {
-    const identifier = isSuspense ? 'infiniteSuspense' : 'infinite';
+  public generateInfiniteQueryKey(config: GenerateConfig): string {
+    const identifier = 'infinite';
     if (config.hasRequiredVariables)
       return `['${config.node.name.value}.${identifier}', variables]`;
     return `variables === undefined ? ['${config.node.name.value}.${identifier}'] : ['${config.node.name.value}.${identifier}', variables]`;
@@ -237,13 +237,13 @@ export abstract class FetcherRenderer {
       hook: this.generateInfiniteQueryHook(config, isSuspense),
       getKey: `${infiniteQuery.getHook(
         operationName,
-      )}.getKey = (${signature}) => ${this.generateInfiniteQueryKey(config, isSuspense)};`,
+      )}.getKey = (${signature}) => ${this.generateInfiniteQueryKey(config)};`,
       rootKey: `${infiniteQuery.getHook(operationName)}.rootKey = '${node.name.value}.infinite';`,
     };
   }
 
-  public generateQueryKey(config: GenerateConfig, isSuspense: boolean): string {
-    const identifier = isSuspense ? `${config.node.name.value}Suspense` : config.node.name.value;
+  public generateQueryKey(config: GenerateConfig): string {
+    const identifier = config.node.name.value;
     if (config.hasRequiredVariables) return `['${identifier}', variables]`;
     return `variables === undefined ? ['${identifier}'] : ['${identifier}', variables]`;
   }
@@ -255,10 +255,7 @@ export abstract class FetcherRenderer {
     return {
       hook: this.generateQueryHook(config, isSuspense),
       document: `${query.getHook(operationName)}.document = ${documentVariableName};`,
-      getKey: `${query.getHook(operationName)}.getKey = (${signature}) => ${this.generateQueryKey(
-        config,
-        isSuspense,
-      )};`,
+      getKey: `${query.getHook(operationName)}.getKey = (${signature}) => ${this.generateQueryKey(config)};`,
       rootKey: `${query.getHook(operationName)}.rootKey = '${node.name.value}';`,
     };
   }

--- a/packages/plugins/typescript/solid-query/src/fetcher.ts
+++ b/packages/plugins/typescript/solid-query/src/fetcher.ts
@@ -89,7 +89,7 @@ export abstract class FetcherRenderer {
     ${implHookOuter}
     return ${infiniteQuery.getHook()}<${operationResultType}, TError, TData>(
       ${this.generateInfiniteQueryFormattedParameters(
-        this.generateInfiniteQueryKey(config, isSuspense),
+        this.generateInfiniteQueryKey(config),
         implFetcher,
       )}
     )};`;
@@ -126,7 +126,7 @@ export abstract class FetcherRenderer {
     ${implHookOuter}
     return ${query.getHook()}<${operationResultType}, TError, TData>(
       ${this.generateQueryFormattedParameters(
-        this.generateQueryKey(config, isSuspense),
+        this.generateQueryKey(config),
         implFetcher,
       )}
     )};`;
@@ -201,8 +201,8 @@ export abstract class FetcherRenderer {
     return `options: Omit<${infiniteQuery.getOptions()}<${operationResultType}, TError, TData>, 'queryKey'> & { queryKey?: ${infiniteQuery.getOptions()}<${operationResultType}, TError, TData>['queryKey'] }`;
   }
 
-  public generateInfiniteQueryKey(config: GenerateConfig, isSuspense: boolean): string {
-    const identifier = isSuspense ? 'infiniteSuspense' : 'infinite';
+  public generateInfiniteQueryKey(config: GenerateConfig): string {
+    const identifier = 'infinite';
     if (config.hasRequiredVariables)
       return `['${config.node.name.value}.${identifier}', variables]`;
     return `variables === undefined ? ['${config.node.name.value}.${identifier}'] : ['${config.node.name.value}.${identifier}', variables]`;
@@ -216,13 +216,13 @@ export abstract class FetcherRenderer {
       hook: this.generateInfiniteQueryHook(config, isSuspense),
       getKey: `${infiniteQuery.getHook(
         operationName,
-      )}.getKey = (${signature}) => ${this.generateInfiniteQueryKey(config, isSuspense)};`,
+      )}.getKey = (${signature}) => ${this.generateInfiniteQueryKey(config)};`,
       rootKey: `${infiniteQuery.getHook(operationName)}.rootKey = '${node.name.value}.infinite';`,
     };
   }
 
-  public generateQueryKey(config: GenerateConfig, isSuspense: boolean): string {
-    const identifier = isSuspense ? `${config.node.name.value}Suspense` : config.node.name.value;
+  public generateQueryKey(config: GenerateConfig): string {
+    const identifier = config.node.name.value;
     if (config.hasRequiredVariables) return `['${identifier}', variables]`;
     return `variables === undefined ? ['${identifier}'] : ['${identifier}', variables]`;
   }
@@ -234,10 +234,7 @@ export abstract class FetcherRenderer {
     return {
       hook: this.generateQueryHook(config, isSuspense),
       document: `${query.getHook(operationName)}.document = ${documentVariableName};`,
-      getKey: `${query.getHook(operationName)}.getKey = (${signature}) => ${this.generateQueryKey(
-        config,
-        isSuspense,
-      )};`,
+      getKey: `${query.getHook(operationName)}.getKey = (${signature}) => ${this.generateQueryKey(config)};`,
       rootKey: `${query.getHook(operationName)}.rootKey = '${node.name.value}';`,
     };
   }


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

**Query keys should be shared between suspense and non-suspense hooks to ensure consistent state management and synchronization, preventing discrepancies and maintaining a single source of truth for query invalidation.**

Related # (issue)

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules