### PR TITLE
Fix selection aliases in usage comment above MSW mock handlers

### DIFF
--- a/packages/plugins/typescript/msw/src/visitor.ts
+++ b/packages/plugins/typescript/msw/src/visitor.ts
@@ -67,7 +67,7 @@ export class MSWVisitor extends ClientSideBaseVisitor<MSWRawPluginConfig, MSWPlu
           }`;
 
           /** @ts-expect-error name DOES exist on @type{import('graphql').SelectionNode} */
-          const selections = node.selectionSet.selections.map(sel => sel.name.value).join(', ');
+          const selections = node.selectionSet.selections.map(sel => (sel.alias || sel.name).value).join(', ');
           const variables = node.variableDefinitions.map(def => def.variable.name.value).join(', ');
 
           return `/**


### PR DESCRIPTION
Fixes minor issue in the usage example when a root selection set has aliases