### PR TITLE
[near-operation-file] only import interface types that are in use

### DIFF
--- a/.changeset/loud-papers-attend.md
+++ b/.changeset/loud-papers-attend.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/near-operation-file-preset': minor
+---
+
+Only import interface types that are used in the document.

--- a/dev-test/githunt/__generated__/comment-added.subscription.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comment-added.subscription.stencil-component.tsx
@@ -4,7 +4,7 @@ import { Component, h, Prop } from '@stencil/core';
 
 declare global {
   export type OnCommentAddedSubscriptionVariables = Types.Exact<{
-    repoFullName: Types.Scalars['String'];
+    repoFullName: Types.Scalars['String']['input'];
   }>;
 
   export type OnCommentAddedSubscription = {

--- a/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/comment.query.stencil-component.tsx
@@ -5,9 +5,9 @@ import { Component, h, Prop } from '@stencil/core';
 
 declare global {
   export type CommentQueryVariables = Types.Exact<{
-    repoFullName: Types.Scalars['String'];
-    limit?: Types.InputMaybe<Types.Scalars['Int']>;
-    offset?: Types.InputMaybe<Types.Scalars['Int']>;
+    repoFullName: Types.Scalars['String']['input'];
+    limit?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+    offset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
   }>;
 
   export type CommentQuery = {

--- a/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
@@ -6,8 +6,8 @@ import { Component, h, Prop } from '@stencil/core';
 declare global {
   export type FeedQueryVariables = Types.Exact<{
     type: Types.FeedType;
-    offset?: Types.InputMaybe<Types.Scalars['Int']>;
-    limit?: Types.InputMaybe<Types.Scalars['Int']>;
+    offset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+    limit?: Types.InputMaybe<Types.Scalars['Int']['input']>;
   }>;
 
   export type FeedQuery = {

--- a/dev-test/githunt/__generated__/new-entry.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/new-entry.mutation.stencil-component.tsx
@@ -4,7 +4,7 @@ import { Component, h, Prop } from '@stencil/core';
 
 declare global {
   export type SubmitRepositoryMutationVariables = Types.Exact<{
-    repoFullName: Types.Scalars['String'];
+    repoFullName: Types.Scalars['String']['input'];
   }>;
 
   export type SubmitRepositoryMutation = {

--- a/dev-test/githunt/__generated__/submit-comment.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/submit-comment.mutation.stencil-component.tsx
@@ -5,8 +5,8 @@ import { Component, h, Prop } from '@stencil/core';
 
 declare global {
   export type SubmitCommentMutationVariables = Types.Exact<{
-    repoFullName: Types.Scalars['String'];
-    commentContent: Types.Scalars['String'];
+    repoFullName: Types.Scalars['String']['input'];
+    commentContent: Types.Scalars['String']['input'];
   }>;
 
   export type SubmitCommentMutation = {

--- a/dev-test/githunt/__generated__/vote.mutation.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/vote.mutation.stencil-component.tsx
@@ -4,7 +4,7 @@ import { Component, h, Prop } from '@stencil/core';
 
 declare global {
   export type VoteMutationVariables = Types.Exact<{
-    repoFullName: Types.Scalars['String'];
+    repoFullName: Types.Scalars['String']['input'];
     type: Types.VoteType;
   }>;
 

--- a/dev-test/githunt/jit-sdk.ts
+++ b/dev-test/githunt/jit-sdk.ts
@@ -172,7 +172,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -187,9 +187,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -255,8 +255,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -283,7 +283,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -304,8 +304,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -326,7 +326,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.apolloAngular.sdk.ts
+++ b/dev-test/githunt/types.apolloAngular.sdk.ts
@@ -172,7 +172,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -187,9 +187,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -255,8 +255,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -283,7 +283,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -304,8 +304,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -326,7 +326,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.apolloAngular.ts
+++ b/dev-test/githunt/types.apolloAngular.ts
@@ -171,7 +171,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -186,9 +186,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -254,8 +254,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -282,7 +282,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -303,8 +303,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -325,7 +325,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -201,7 +201,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -216,9 +216,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -284,8 +284,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -312,7 +312,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -333,8 +333,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -355,7 +355,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -171,7 +171,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscriptionMyOperation = {
@@ -186,9 +186,9 @@ export type OnCommentAddedSubscriptionMyOperation = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQueryMyOperation = {
@@ -254,8 +254,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQueryMyOperation = {
@@ -282,7 +282,7 @@ export type FeedQueryMyOperation = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutationMyOperation = {
@@ -303,8 +303,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutationMyOperation = {
@@ -325,7 +325,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -171,7 +171,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -186,9 +186,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -254,8 +254,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -282,7 +282,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -303,8 +303,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -325,7 +325,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -171,7 +171,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -186,9 +186,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -254,8 +254,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -282,7 +282,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -303,8 +303,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -325,7 +325,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -171,7 +171,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -186,9 +186,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -254,8 +254,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -282,7 +282,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -303,8 +303,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -325,7 +325,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.reactApollo.v2.tsx
+++ b/dev-test/githunt/types.reactApollo.v2.tsx
@@ -172,7 +172,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -187,9 +187,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -255,8 +255,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -283,7 +283,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -304,8 +304,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -326,7 +326,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.rtk-query.ts
+++ b/dev-test/githunt/types.rtk-query.ts
@@ -170,7 +170,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -185,9 +185,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -253,8 +253,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -281,7 +281,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -302,8 +302,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -324,7 +324,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.stencilApollo.tsx
+++ b/dev-test/githunt/types.stencilApollo.tsx
@@ -171,7 +171,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -186,9 +186,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -254,8 +254,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -282,7 +282,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -303,8 +303,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -325,7 +325,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.urql.tsx
+++ b/dev-test/githunt/types.urql.tsx
@@ -178,7 +178,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -193,9 +193,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -261,8 +261,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -289,7 +289,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -310,8 +310,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -332,7 +332,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.vueApollo.ts
+++ b/dev-test/githunt/types.vueApollo.ts
@@ -172,7 +172,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -187,9 +187,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -255,8 +255,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -283,7 +283,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -304,8 +304,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -326,7 +326,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/githunt/types.vueApolloSmartOps.ts
+++ b/dev-test/githunt/types.vueApolloSmartOps.ts
@@ -175,7 +175,7 @@ export enum VoteType {
 }
 
 export type OnCommentAddedSubscriptionVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type OnCommentAddedSubscription = {
@@ -190,9 +190,9 @@ export type OnCommentAddedSubscription = {
 };
 
 export type CommentQueryVariables = Exact<{
-  repoFullName: Scalars['String'];
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
+  repoFullName: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type CommentQuery = {
@@ -258,8 +258,8 @@ export type FeedEntryFragment = {
 
 export type FeedQueryVariables = Exact<{
   type: FeedType;
-  offset?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 export type FeedQuery = {
@@ -286,7 +286,7 @@ export type FeedQuery = {
 };
 
 export type SubmitRepositoryMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
 }>;
 
 export type SubmitRepositoryMutation = {
@@ -307,8 +307,8 @@ export type RepoInfoFragment = {
 };
 
 export type SubmitCommentMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
-  commentContent: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
+  commentContent: Scalars['String']['input'];
 }>;
 
 export type SubmitCommentMutation = {
@@ -329,7 +329,7 @@ export type VoteButtonsFragment = {
 };
 
 export type VoteMutationVariables = Exact<{
-  repoFullName: Scalars['String'];
+  repoFullName: Scalars['String']['input'];
   type: VoteType;
 }>;
 

--- a/dev-test/star-wars/__generated__/HeroNameConditional.tsx
+++ b/dev-test/star-wars/__generated__/HeroNameConditional.tsx
@@ -5,7 +5,7 @@ import * as Types from '../types.d.js';
 const defaultOptions = {} as const;
 export type HeroNameConditionalInclusionQueryVariables = Types.Exact<{
   episode?: Types.InputMaybe<Types.Episode>;
-  includeName: Types.Scalars['Boolean'];
+  includeName: Types.Scalars['Boolean']['input'];
 }>;
 
 export type HeroNameConditionalInclusionQuery = {
@@ -15,7 +15,7 @@ export type HeroNameConditionalInclusionQuery = {
 
 export type HeroNameConditionalExclusionQueryVariables = Types.Exact<{
   episode?: Types.InputMaybe<Types.Episode>;
-  skipName: Types.Scalars['Boolean'];
+  skipName: Types.Scalars['Boolean']['input'];
 }>;
 
 export type HeroNameConditionalExclusionQuery = {

--- a/dev-test/test-message/types.tsx
+++ b/dev-test/test-message/types.tsx
@@ -60,7 +60,7 @@ export type QueryMessagesArgs = {
 };
 
 export type GetMessagesQueryVariables = Exact<{
-  tab: Scalars['String'];
+  tab: Scalars['String']['input'];
 }>;
 
 export type GetMessagesQuery = {
@@ -78,8 +78,8 @@ export type CreateMessageMutation = {
 };
 
 export type DeclineMutationVariables = Exact<{
-  id: Scalars['ID'];
-  reason: Scalars['String'];
+  id: Scalars['ID']['input'];
+  reason: Scalars['String']['input'];
 }>;
 
 export type DeclineMutation = {
@@ -88,7 +88,7 @@ export type DeclineMutation = {
 };
 
 export type ApproveMutationVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 }>;
 
 export type ApproveMutation = {
@@ -97,7 +97,7 @@ export type ApproveMutation = {
 };
 
 export type EscalateMutationVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 }>;
 
 export type EscalateMutation = {

--- a/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/generic-sdk/tests/__snapshots__/generic-sdk.spec.ts.snap
@@ -183,21 +183,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -924,21 +924,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -1197,21 +1197,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 

--- a/packages/plugins/typescript/graphql-apollo/package.json
+++ b/packages/plugins/typescript/graphql-apollo/package.json
@@ -51,7 +51,7 @@
     "@apollo/client": "3.13.8",
     "@graphql-codegen/core": "2.6.8",
     "@graphql-codegen/testing": "1.18.3",
-    "@graphql-codegen/typescript-operations": "2.5.13",
+    "@graphql-codegen/typescript-operations": "4.6.1",
     "@graphql-tools/schema": "10.0.23",
     "cross-fetch": "3.2.0",
     "react": "19.1.0"

--- a/packages/plugins/typescript/graphql-apollo/tests/__snapshots__/graphql-apollo.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-apollo/tests/__snapshots__/graphql-apollo.spec.ts.snap
@@ -183,7 +183,7 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type ListenToCommentsSubscriptionVariables = Exact<{
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -197,21 +197,21 @@ export type MutationOperationMutationVariables = Exact<{
 export type MutationOperationMutation = { __typename?: 'Mutation', submitComment?: { __typename?: 'Comment', id: number } | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -489,7 +489,7 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type ListenToCommentsSubscriptionVariables = Exact<{
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -503,21 +503,21 @@ export type MutationOperationMutationVariables = Exact<{
 export type MutationOperationMutation = { __typename?: 'Mutation', submitComment?: { __typename?: 'Comment', id: number } | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 

--- a/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
+++ b/packages/plugins/typescript/graphql-request/tests/__snapshots__/graphql-request.spec.ts.snap
@@ -183,21 +183,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -469,21 +469,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -747,21 +747,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -1027,21 +1027,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -1310,21 +1310,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -1590,21 +1590,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -1871,21 +1871,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -2155,21 +2155,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -2438,21 +2438,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -2718,21 +2718,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 

--- a/packages/plugins/typescript/jit-sdk/tests/__snapshots__/jit-sdk.spec.ts.snap
+++ b/packages/plugins/typescript/jit-sdk/tests/__snapshots__/jit-sdk.spec.ts.snap
@@ -185,21 +185,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 
@@ -970,21 +970,21 @@ export type FeedQueryVariables = Exact<{ [key: string]: never; }>;
 export type FeedQuery = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number, commentCount: number, repository: { __typename?: 'Repository', owner?: { __typename?: 'User', avatar_url: string } | null } } | null> | null };
 
 export type Feed2QueryVariables = Exact<{
-  v: Scalars['String'];
+  v: Scalars['String']['input'];
 }>;
 
 
 export type Feed2Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed3QueryVariables = Exact<{
-  v?: InputMaybe<Scalars['String']>;
+  v?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type Feed3Query = { __typename?: 'Query', feed?: Array<{ __typename?: 'Entry', id: number } | null> | null };
 
 export type Feed4QueryVariables = Exact<{
-  v?: Scalars['String'];
+  v?: Scalars['String']['input'];
 }>;
 
 

--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -12,7 +12,7 @@ import {
   RawConfig,
 } from '@graphql-codegen/visitor-plugin-common';
 import { DocumentImportResolverOptions } from './resolve-document-imports.js';
-import { extractExternalFragmentsInUse } from './utils.js';
+import { analyzeFragmentUsage } from './utils.js';
 
 export interface NearOperationFileParsedConfig extends ParsedConfig {
   importTypesNamespace?: string;
@@ -28,91 +28,95 @@ export type FragmentRegistry = {
     onType: string;
     node: FragmentDefinitionNode;
     imports: Array<FragmentImport>;
+    possibleTypes: string[];
   };
 };
 
 /**
- * Used by `buildFragmentResolver` to  build a mapping of fragmentNames to paths, importNames, and other useful info
+ * Creates fragment imports based on possible types and usage
  */
-function buildFragmentRegistry(
-  { generateFilePath }: DocumentImportResolverOptions,
-  { documents, config }: Types.PresetFnArgs<{}>,
-  schemaObject: GraphQLSchema,
-): FragmentRegistry {
-  const baseVisitor = new BaseVisitor<RawConfig, NearOperationFileParsedConfig>(config, {
-    scalars: buildScalarsFromConfig(schemaObject, config),
-    dedupeOperationSuffix: getConfigValue(config.dedupeOperationSuffix, false),
-    omitOperationSuffix: getConfigValue(config.omitOperationSuffix, false),
-    fragmentVariablePrefix: getConfigValue(config.fragmentVariablePrefix, ''),
-    fragmentVariableSuffix: getConfigValue(config.fragmentVariableSuffix, 'FragmentDoc'),
+function createFragmentImports(
+  baseVisitor: BaseVisitor<RawConfig, NearOperationFileParsedConfig>,
+  fragmentName: string,
+  possibleTypes: string[],
+  usedTypes?: string[],
+): Array<FragmentImport> {
+  const fragmentImports: Array<FragmentImport> = [];
+
+  // Always include the document import
+  fragmentImports.push({
+    name: baseVisitor.getFragmentVariableName(fragmentName),
+    kind: 'document',
   });
 
-  const getFragmentImports = (possbileTypes: string[], name: string): Array<FragmentImport> => {
-    const fragmentImports: Array<FragmentImport> = [];
+  const fragmentSuffix = baseVisitor.getFragmentSuffix(fragmentName);
 
-    fragmentImports.push({ name: baseVisitor.getFragmentVariableName(name), kind: 'document' });
+  if (possibleTypes.length === 1) {
+    fragmentImports.push({
+      name: baseVisitor.convertName(fragmentName, {
+        useTypesPrefix: true,
+        suffix: fragmentSuffix,
+      }),
+      kind: 'type',
+    });
+  } else if (possibleTypes.length > 0) {
+    const typesToImport = usedTypes && usedTypes.length > 0 ? usedTypes : possibleTypes;
 
-    const fragmentSuffix = baseVisitor.getFragmentSuffix(name);
-    if (possbileTypes.length === 1) {
+    typesToImport.forEach(typeName => {
       fragmentImports.push({
-        name: baseVisitor.convertName(name, {
+        name: baseVisitor.convertName(fragmentName, {
           useTypesPrefix: true,
-          suffix: fragmentSuffix,
+          suffix: `_${typeName}` + (fragmentSuffix.length > 0 ? `_${fragmentSuffix}` : ''),
         }),
         kind: 'type',
       });
-    } else if (possbileTypes.length !== 0) {
-      possbileTypes.forEach(typeName => {
-        fragmentImports.push({
-          name: baseVisitor.convertName(name, {
-            useTypesPrefix: true,
-            suffix: `_${typeName}_${fragmentSuffix}`,
-          }),
-          kind: 'type',
-        });
-      });
-    }
+    });
+  }
 
-    return fragmentImports;
-  };
+  return fragmentImports;
+}
 
+/**
+ * Used by `buildFragmentResolver` to build a mapping of fragmentNames to paths, importNames, and other useful info
+ */
+function buildFragmentRegistry(
+  baseVisitor: BaseVisitor<RawConfig, NearOperationFileParsedConfig>,
+  { generateFilePath }: DocumentImportResolverOptions,
+  { documents }: Types.PresetFnArgs<{}>,
+  schemaObject: GraphQLSchema,
+): FragmentRegistry {
   const duplicateFragmentNames: string[] = [];
   const registry = documents.reduce<FragmentRegistry>((prev: FragmentRegistry, documentRecord) => {
     const fragments: FragmentDefinitionNode[] = documentRecord.document.definitions.filter(
       d => d.kind === Kind.FRAGMENT_DEFINITION,
     ) as FragmentDefinitionNode[];
 
-    if (fragments.length > 0) {
-      for (const fragment of fragments) {
-        const schemaType = schemaObject.getType(fragment.typeCondition.name.value);
+    for (const fragment of fragments) {
+      const schemaType = schemaObject.getType(fragment.typeCondition.name.value);
 
-        if (!schemaType) {
-          throw new Error(
-            `Fragment "${fragment.name.value}" is set on non-existing type "${fragment.typeCondition.name.value}"!`,
-          );
-        }
-
-        const possibleTypes = getPossibleTypes(schemaObject, schemaType);
-        const filePath = generateFilePath(documentRecord.location);
-        const imports = getFragmentImports(
-          possibleTypes.map(t => t.name),
-          fragment.name.value,
+      if (!schemaType) {
+        throw new Error(
+          `Fragment "${fragment.name.value}" is set on non-existing type "${fragment.typeCondition.name.value}"!`,
         );
-
-        if (
-          prev[fragment.name.value] &&
-          print(fragment) !== print(prev[fragment.name.value].node)
-        ) {
-          duplicateFragmentNames.push(fragment.name.value);
-        }
-
-        prev[fragment.name.value] = {
-          filePath,
-          imports,
-          onType: fragment.typeCondition.name.value,
-          node: fragment,
-        };
       }
+
+      const fragmentName = fragment.name.value;
+      const filePath = generateFilePath(documentRecord.location);
+      const possibleTypes = getPossibleTypes(schemaObject, schemaType);
+      const possibleTypeNames = possibleTypes.map(t => t.name);
+      const imports = createFragmentImports(baseVisitor, fragment.name.value, possibleTypeNames);
+
+      if (prev[fragmentName] && print(fragment) !== print(prev[fragmentName].node)) {
+        duplicateFragmentNames.push(fragmentName);
+      }
+
+      prev[fragmentName] = {
+        filePath,
+        imports,
+        onType: fragment.typeCondition.name.value,
+        node: fragment,
+        possibleTypes: possibleTypeNames,
+      };
     }
 
     return prev;
@@ -128,7 +132,23 @@ function buildFragmentRegistry(
 }
 
 /**
- *  Builds a fragment "resolver" that collects `externalFragments` definitions and `fragmentImportStatements`
+ * Creates a BaseVisitor with standard configuration
+ */
+function createBaseVisitor(
+  config: { [key: string]: any },
+  schemaObject: GraphQLSchema,
+): BaseVisitor<RawConfig, NearOperationFileParsedConfig> {
+  return new BaseVisitor<RawConfig, NearOperationFileParsedConfig>(config, {
+    scalars: buildScalarsFromConfig(schemaObject, config),
+    dedupeOperationSuffix: getConfigValue(config.dedupeOperationSuffix, false),
+    omitOperationSuffix: getConfigValue(config.omitOperationSuffix, false),
+    fragmentVariablePrefix: getConfigValue(config.fragmentVariablePrefix, ''),
+    fragmentVariableSuffix: getConfigValue(config.fragmentVariableSuffix, 'FragmentDoc'),
+  });
+}
+
+/**
+ * Builds a fragment "resolver" that collects `externalFragments` definitions and `fragmentImportStatements`
  */
 export default function buildFragmentResolver<T>(
   collectorOptions: DocumentImportResolverOptions,
@@ -136,47 +156,65 @@ export default function buildFragmentResolver<T>(
   schemaObject: GraphQLSchema,
   dedupeFragments = false,
 ) {
-  const fragmentRegistry = buildFragmentRegistry(collectorOptions, presetOptions, schemaObject);
+  const { config } = presetOptions;
+  const baseVisitor = createBaseVisitor(config, schemaObject);
+  const fragmentRegistry = buildFragmentRegistry(
+    baseVisitor,
+    collectorOptions,
+    presetOptions,
+    schemaObject,
+  );
   const { baseOutputDir } = presetOptions;
   const { baseDir, typesImport } = collectorOptions;
 
   function resolveFragments(generatedFilePath: string, documentFileContent: DocumentNode) {
-    const fragmentsInUse = extractExternalFragmentsInUse(documentFileContent, fragmentRegistry);
+    const { fragmentsInUse, usedFragmentTypes } = analyzeFragmentUsage(
+      documentFileContent,
+      fragmentRegistry,
+      schemaObject,
+    );
 
     const externalFragments: LoadedFragment<{ level: number }>[] = [];
-    // fragment files to import names
     const fragmentFileImports: { [fragmentFile: string]: Array<FragmentImport> } = {};
-    for (const fragmentName of Object.keys(fragmentsInUse)) {
-      const level = fragmentsInUse[fragmentName];
-      const fragmentDetails = fragmentRegistry[fragmentName];
-      if (fragmentDetails) {
-        // add top level references to the import object
-        // we don't checkf or global namespace because the calling config can do so
-        if (
-          level === 0 ||
-          (dedupeFragments &&
-            ['OperationDefinition', 'FragmentDefinition'].includes(
-              documentFileContent.definitions[0].kind,
-            ))
-        ) {
-          if (fragmentDetails.filePath !== generatedFilePath) {
-            // don't emit imports to same location
-            if (fragmentFileImports[fragmentDetails.filePath] === undefined) {
-              fragmentFileImports[fragmentDetails.filePath] = fragmentDetails.imports;
-            } else {
-              fragmentFileImports[fragmentDetails.filePath].push(...fragmentDetails.imports);
-            }
-          }
-        }
 
-        externalFragments.push({
-          level,
-          isExternal: true,
-          name: fragmentName,
-          onType: fragmentDetails.onType,
-          node: fragmentDetails.node,
-        });
+    for (const [fragmentName, level] of Object.entries(fragmentsInUse)) {
+      const fragmentDetails = fragmentRegistry[fragmentName];
+
+      if (!fragmentDetails) continue;
+
+      // add top level references to the import object
+      // we don't check or global namespace because the calling config can do so
+      if (
+        level === 0 ||
+        (dedupeFragments &&
+          ['OperationDefinition', 'FragmentDefinition'].includes(
+            documentFileContent.definitions[0].kind,
+          ))
+      ) {
+        if (fragmentDetails.filePath !== generatedFilePath) {
+          // don't emit imports to same location
+          const usedTypesForFragment = usedFragmentTypes[fragmentName] || [];
+          const filteredImports = createFragmentImports(
+            baseVisitor,
+            fragmentName,
+            fragmentDetails.possibleTypes,
+            usedTypesForFragment,
+          );
+
+          if (!fragmentFileImports[fragmentDetails.filePath]) {
+            fragmentFileImports[fragmentDetails.filePath] = [];
+          }
+          fragmentFileImports[fragmentDetails.filePath].push(...filteredImports);
+        }
       }
+
+      externalFragments.push({
+        level,
+        isExternal: true,
+        name: fragmentName,
+        onType: fragmentDetails.onType,
+        node: fragmentDetails.node,
+      });
     }
 
     return {
@@ -196,5 +234,6 @@ export default function buildFragmentResolver<T>(
       ),
     };
   }
+
   return resolveFragments;
 }

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -1,7 +1,20 @@
 import { join } from 'path';
-import { DocumentNode, FragmentDefinitionNode, FragmentSpreadNode } from 'graphql';
+import {
+  DocumentNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  GraphQLSchema,
+  GraphQLType,
+  isInterfaceType,
+  isObjectType,
+  isUnionType,
+  SelectionSetNode,
+  TypeInfo,
+  visit,
+  visitWithTypeInfo,
+} from 'graphql';
 import parsePath from 'parse-filepath';
-import { oldVisit } from '@graphql-codegen/plugin-helpers';
+import { getPossibleTypes, separateSelectionSet } from '@graphql-codegen/visitor-plugin-common';
 import { FragmentRegistry } from './fragment-resolver.js';
 
 export function defineFilepathSubfolder(baseFilePath: string, folder: string) {
@@ -16,49 +29,187 @@ export function appendFileNameToFilePath(
 ) {
   const parsedPath = parsePath(baseFilePath);
   const name = fileName || parsedPath.name;
-
   return join(parsedPath.dir, name + extension).replace(/\\/g, '/');
+}
+
+/**
+ * Analyzes fragment usage in a GraphQL document.
+ * Returns information about which fragments are used and which specific types they're used with.
+ */
+export function analyzeFragmentUsage(
+  documentNode: DocumentNode,
+  fragmentRegistry: FragmentRegistry,
+  schema: GraphQLSchema,
+): {
+  fragmentsInUse: { [fragmentName: string]: number };
+  usedFragmentTypes: { [fragmentName: string]: string[] };
+} {
+  const localFragments = getLocalFragments(documentNode);
+
+  const fragmentsInUse = extractExternalFragmentsInUse(
+    documentNode,
+    fragmentRegistry,
+    localFragments,
+  );
+
+  const usedFragmentTypes = analyzeFragmentTypeUsage(
+    documentNode,
+    fragmentRegistry,
+    schema,
+    localFragments,
+    fragmentsInUse,
+  );
+
+  return { fragmentsInUse, usedFragmentTypes };
+}
+
+/**
+ * Get all fragment definitions that are local to this document
+ */
+function getLocalFragments(documentNode: DocumentNode): Set<string> {
+  const localFragments = new Set<string>();
+  visit(documentNode, {
+    FragmentDefinition: node => {
+      localFragments.add(node.name.value);
+    },
+  });
+  return localFragments;
 }
 
 export function extractExternalFragmentsInUse(
   documentNode: DocumentNode | FragmentDefinitionNode,
   fragmentNameToFile: FragmentRegistry,
+  localFragment: Set<string>,
   result: { [fragmentName: string]: number } = {},
   level = 0,
 ): { [fragmentName: string]: number } {
-  const ignoreList: Set<string> = new Set();
-
-  // First, take all fragments definition from the current file, and mark them as ignored
-  oldVisit(documentNode, {
-    enter: {
-      FragmentDefinition: (node: FragmentDefinitionNode) => {
-        ignoreList.add(node.name.value);
-      },
-    },
-  });
-
   // Then, look for all used fragments in this document
-  oldVisit(documentNode, {
-    enter: {
-      FragmentSpread: (node: FragmentSpreadNode) => {
-        if (
-          !ignoreList.has(node.name.value) &&
-          (result[node.name.value] === undefined || level < result[node.name.value])
-        ) {
-          result[node.name.value] = level;
+  visit(documentNode, {
+    FragmentSpread: node => {
+      if (
+        !localFragment.has(node.name.value) &&
+        (result[node.name.value] === undefined || level < result[node.name.value])
+      ) {
+        result[node.name.value] = level;
 
-          if (fragmentNameToFile[node.name.value]) {
-            extractExternalFragmentsInUse(
-              fragmentNameToFile[node.name.value].node,
-              fragmentNameToFile,
-              result,
-              level + 1,
-            );
-          }
+        if (fragmentNameToFile[node.name.value]) {
+          extractExternalFragmentsInUse(
+            fragmentNameToFile[node.name.value].node,
+            fragmentNameToFile,
+            localFragment,
+            result,
+            level + 1,
+          );
         }
-      },
+      }
     },
   });
 
   return result;
+}
+
+/**
+ * Analyze which specific types each fragment is used with (for polymorphic fragments)
+ */
+function analyzeFragmentTypeUsage(
+  documentNode: DocumentNode,
+  fragmentRegistry: FragmentRegistry,
+  schema: GraphQLSchema,
+  localFragments: Set<string>,
+  fragmentsInUse: { [fragmentName: string]: number },
+): { [fragmentName: string]: string[] } {
+  const usedFragmentTypes: { [fragmentName: string]: Set<string> } = {};
+  const typeInfo = new TypeInfo(schema);
+
+  visit(
+    documentNode,
+    visitWithTypeInfo(typeInfo, {
+      Field: (node: FieldNode) => {
+        if (!node.selectionSet) return;
+
+        const fieldType = typeInfo.getType();
+        if (!fieldType) return;
+
+        const baseType = getBaseType(fieldType);
+        if (isObjectType(baseType) || isInterfaceType(baseType) || isUnionType(baseType)) {
+          analyzeSelectionSetTypeContext(
+            node.selectionSet,
+            baseType.name,
+            usedFragmentTypes,
+            fragmentRegistry,
+            schema,
+            localFragments,
+          );
+        }
+      },
+    }),
+  );
+
+  const result: { [fragmentName: string]: string[] } = {};
+
+  // Fill in missing types for multi-type fragments
+  for (const fragmentName in fragmentsInUse) {
+    const fragment = fragmentRegistry[fragmentName];
+    if (!fragment || fragment.possibleTypes.length <= 1) continue;
+
+    const usedTypes = usedFragmentTypes[fragmentName];
+    result[fragmentName] = usedTypes?.size > 0 ? Array.from(usedTypes) : fragment.possibleTypes;
+  }
+
+  return result;
+}
+
+/**
+ * Analyze fragment usage within a specific selection set and type context
+ */
+function analyzeSelectionSetTypeContext(
+  selectionSet: SelectionSetNode,
+  currentTypeName: string,
+  usedFragmentTypes: { [fragmentName: string]: Set<string> },
+  fragmentRegistry: FragmentRegistry,
+  schema: GraphQLSchema,
+  localFragments: Set<string>,
+): void {
+  const { spreads, inlines } = separateSelectionSet(selectionSet.selections);
+
+  // Process fragment spreads in this type context
+  for (const spread of spreads) {
+    if (localFragments.has(spread.name.value)) continue;
+
+    const fragment = fragmentRegistry[spread.name.value];
+    if (!fragment || fragment.possibleTypes.length <= 1) continue;
+
+    const currentType = schema.getType(currentTypeName);
+    if (!currentType) continue;
+
+    const possibleTypes = getPossibleTypes(schema, currentType).map(t => t.name);
+    const matchingTypes = possibleTypes.filter(type => fragment.possibleTypes.includes(type));
+
+    if (matchingTypes.length > 0) {
+      const typeSet = (usedFragmentTypes[spread.name.value] ??= new Set());
+      matchingTypes.forEach(type => typeSet.add(type));
+    }
+  }
+
+  // Process inline fragments
+  for (const inline of inlines) {
+    if (inline.typeCondition?.name.value && inline.selectionSet) {
+      analyzeSelectionSetTypeContext(
+        inline.selectionSet,
+        inline.typeCondition.name.value,
+        usedFragmentTypes,
+        fragmentRegistry,
+        schema,
+        localFragments,
+      );
+    }
+  }
+}
+
+function getBaseType(type: GraphQLType): GraphQLType {
+  let baseType = type;
+  while ('ofType' in baseType && baseType.ofType) {
+    baseType = baseType.ofType;
+  }
+  return baseType;
 }

--- a/packages/presets/near-operation-file/tests/fixtures/issue-1112-interface.ts
+++ b/packages/presets/near-operation-file/tests/fixtures/issue-1112-interface.ts
@@ -1,0 +1,5 @@
+export const AnimalFragment = /* GraphQL */ `
+  fragment AnimalFragment on IAnimal {
+    name
+  }
+`;

--- a/packages/presets/near-operation-file/tests/fixtures/issue-1112-operation.ts
+++ b/packages/presets/near-operation-file/tests/fixtures/issue-1112-operation.ts
@@ -1,0 +1,7 @@
+export const CatsQuery = /* GraphQL */ `
+  query Cats {
+    cats {
+      ...AnimalFragment
+    }
+  }
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,7 +1396,7 @@
     "@graphql-tools/utils" "^9.1.1"
     tslib "~2.4.0"
 
-"@graphql-codegen/plugin-helpers@5.1.1", "@graphql-codegen/plugin-helpers@^5.0.4", "@graphql-codegen/plugin-helpers@^5.1.0":
+"@graphql-codegen/plugin-helpers@5.1.1", "@graphql-codegen/plugin-helpers@^5.0.3", "@graphql-codegen/plugin-helpers@^5.0.4", "@graphql-codegen/plugin-helpers@^5.1.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.1.1.tgz#b7c744c8826367c3002c346112de3cd1b0f99b16"
   integrity sha512-28GHODK2HY1NhdyRcPP3sCz0Kqxyfiz7boIZ8qIxFYmpLYnlDgiYok5fhFLVSZihyOpCs4Fa37gVHf/Q4I2FEg==
@@ -1450,6 +1450,15 @@
     "@graphql-tools/utils" "^9.0.0"
     tslib "~2.5.0"
 
+"@graphql-codegen/schema-ast@^4.0.2":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-4.1.0.tgz#a1e71f99346495b9272161a9ed07756e82648726"
+  integrity sha512-kZVn0z+th9SvqxfKYgztA6PM7mhnSZaj4fiuBWvMTqA+QqQ9BBed6Pz41KuD/jr0gJtnlr2A4++/0VlpVbCTmQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^5.0.3"
+    "@graphql-tools/utils" "^10.0.0"
+    tslib "~2.6.0"
+
 "@graphql-codegen/testing@1.18.3":
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/testing/-/testing-1.18.3.tgz#35ffe200c13c29aa93f41cb62b043552b860c72a"
@@ -1462,18 +1471,18 @@
     nock "13.3.0"
     tslib "~2.4.0"
 
-"@graphql-codegen/typescript-operations@2.5.13":
-  version "2.5.13"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.5.13.tgz#f286c37f9c023356aacaa983ebd32e9e021a05ca"
-  integrity sha512-3vfR6Rx6iZU0JRt29GBkFlrSNTM6t+MSLF86ChvL4d/Jfo/JYAGuB3zNzPhirHYzJPCvLOAx2gy9ID1ltrpYiw==
+"@graphql-codegen/typescript-operations@4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-4.6.1.tgz#763eda28c77fddee2b9ae9bd7baad050cffff0a5"
+  integrity sha512-k92laxhih7s0WZ8j5WMIbgKwhe64C0As6x+PdcvgZFMudDJ7rPJ/hFqJ9DCRxNjXoHmSjnr6VUuQZq4lT1RzCA==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^3.1.2"
-    "@graphql-codegen/typescript" "^2.8.8"
-    "@graphql-codegen/visitor-plugin-common" "2.13.8"
+    "@graphql-codegen/plugin-helpers" "^5.1.0"
+    "@graphql-codegen/typescript" "^4.1.6"
+    "@graphql-codegen/visitor-plugin-common" "5.8.0"
     auto-bind "~4.0.0"
-    tslib "~2.4.0"
+    tslib "~2.6.0"
 
-"@graphql-codegen/typescript@^2.8.1", "@graphql-codegen/typescript@^2.8.8":
+"@graphql-codegen/typescript@^2.8.1":
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.8.8.tgz#8c3b9153e334db43c65f8f31ced69b4c60d14861"
   integrity sha512-A0oUi3Oy6+DormOlrTC4orxT9OBZkIglhbJBcDmk34jAKKUgesukXRd4yOhmTrnbchpXz2T8IAOFB3FWIaK4Rw==
@@ -1494,6 +1503,17 @@
     "@graphql-codegen/visitor-plugin-common" "3.1.1"
     auto-bind "~4.0.0"
     tslib "~2.5.0"
+
+"@graphql-codegen/typescript@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-4.1.6.tgz#f3481ccc1656e96892d629671fb2cff5dabc458b"
+  integrity sha512-vpw3sfwf9A7S+kIUjyFxuvrywGxd4lmwmyYnnDVjVE4kSQ6Td3DpqaPTy8aNQ6O96vFoi/bxbZS2BW49PwSUUA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^5.1.0"
+    "@graphql-codegen/schema-ast" "^4.0.2"
+    "@graphql-codegen/visitor-plugin-common" "5.8.0"
+    auto-bind "~4.0.0"
+    tslib "~2.6.0"
 
 "@graphql-codegen/visitor-plugin-common@2.13.8", "@graphql-codegen/visitor-plugin-common@^2.12.1":
   version "2.13.8"
@@ -1527,7 +1547,7 @@
     parse-filepath "^1.0.2"
     tslib "~2.5.0"
 
-"@graphql-codegen/visitor-plugin-common@^5.3.1":
+"@graphql-codegen/visitor-plugin-common@5.8.0", "@graphql-codegen/visitor-plugin-common@^5.3.1":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.8.0.tgz#1b796453eb96d8e6ad5d4d3acff304e4672781a0"
   integrity sha512-lC1E1Kmuzi3WZUlYlqB4fP6+CvbKH9J+haU1iWmgsBx5/sO2ROeXJG4Dmt8gP03bI2BwjiwV5WxCEMlyeuzLnA==
@@ -7213,16 +7233,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7288,14 +7299,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7838,7 +7842,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7851,15 +7855,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description

Related #1112

This PR addresses the issue by improving **near-operation-file-preset**'s **fragment resolver** to only include import interface types that are used in the current file.

I've used `selection-set-to-object` for inspiration.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

* Unit test is provided.
* I've also tested the changes against a large codebase with 100s of GraphQL files and it worked without issues.

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
