### PR TITLE
Prevent duplicate class generation by using the property name (instead of the GQL type name) as the basis for class name generation 

### DIFF
--- a/.changeset/light-actors-trade.md
+++ b/.changeset/light-actors-trade.md
@@ -1,0 +1,6 @@
+---
+'@graphql-codegen/c-sharp-operations': minor
+---
+
+Prevent duplicate class generation by using the property name (instead of the GQL type name) as the
+basis for class name generation

--- a/.changeset/swift-pens-prove.md
+++ b/.changeset/swift-pens-prove.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/c-sharp-common': patch
+---
+
+Fully qualify enum attributes

--- a/packages/plugins/c-sharp/c-sharp-common/src/json-attributes.ts
+++ b/packages/plugins/c-sharp/c-sharp-common/src/json-attributes.ts
@@ -34,8 +34,8 @@ const newtonsoftConfiguration = new JsonAttributesSourceConfiguration(
   'JsonRequired',
   {
     decorator:
-      '[DataContract]\n[JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]',
-    enumMemberAttribute: value => `[EnumMember(Value = "${value}")]`,
+      '[System.Runtime.Serialization.DataContract]\n[JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]',
+    enumMemberAttribute: value => `[System.Runtime.Serialization.EnumMember(Value = "${value}")]`,
   },
 );
 

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -355,7 +355,10 @@ export class CSharpOperationsVisitor extends ClientSideBaseVisitor<
             ].join('\n') + '\n',
           );
         }
-        const selectionBaseTypeName = `${responseType.baseType.type}Selection`;
+        let selectionBaseTypeName = `${node.name.value}Selection`;
+        // Ensure PascalCase
+        selectionBaseTypeName =
+          selectionBaseTypeName.charAt(0).toUpperCase() + selectionBaseTypeName.slice(1);
         const selectionType = Object.assign(new CSharpFieldType(responseType), {
           baseType: { type: selectionBaseTypeName },
         });

--- a/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
@@ -273,12 +273,12 @@ describe('C# Operations', () => {
       )) as Types.ComplexPluginOutput;
       expect(result.content).toBeSimilarStringTo(`
         public class Response {
-          public class PersonSelection {
+          public class MeSelection {
             [JsonProperty("friendIds")]
             public System.Collections.Generic.List<int> friendIds { get; set; }
           }
           [JsonProperty("me")]
-          public PersonSelection me { get; set; }
+          public MeSelection me { get; set; }
         }
       `);
     });
@@ -380,12 +380,12 @@ describe('C# Operations', () => {
           public string @record { get; set; }
         }
         public class Response {
-          public class CourtCaseSelection {
+          public class CaseSelection {
             [JsonProperty("operator")]
             public string @operator { get; set; }
           }
           [JsonProperty("case")]
-          public CourtCaseSelection @case { get; set; }
+          public CaseSelection @case { get; set; }
         }
       `);
     });
@@ -574,12 +574,12 @@ describe('C# Operations', () => {
       )) as Types.ComplexPluginOutput;
       expect(result.content).toBeSimilarStringTo(`
         public class Response {
-          public class PersonSelection {
+          public class MeSelection {
             [JsonProperty("friendIds")]
             public System.Collections.Generic.List<int> friendIds { get; set; }
           }
           [JsonProperty("me")]
-          public PersonSelection me { get; set; }
+          public MeSelection me { get; set; }
         }
       `);
     });
@@ -683,12 +683,12 @@ describe('C# Operations', () => {
           public string @record { get; set; }
         }
         public class Response {
-          public class CourtCaseSelection {
+          public class CaseSelection {
             [JsonProperty("operator")]
             public string @operator { get; set; }
           }
           [JsonProperty("case")]
-          public CourtCaseSelection @case { get; set; }
+          public CaseSelection @case { get; set; }
         }
       `);
     });
@@ -883,12 +883,12 @@ describe('C# Operations', () => {
       )) as Types.ComplexPluginOutput;
       expect(result.content).toBeSimilarStringTo(`
         public class Response {
-          public class PersonSelection {
+          public class YouSelection {
             [JsonProperty("friendIds")]
             public System.Collections.Generic.List<int> friendIds { get; set; }
           }
           [JsonProperty("you")]
-          public PersonSelection you { get; set; }
+          public YouSelection you { get; set; }
         }
       `);
     });
@@ -998,12 +998,12 @@ describe('C# Operations', () => {
           public string @record { get; set; }
         }
         public class Response {
-          public class CourtCaseSelection {
+          public class CaseSelection {
             [JsonProperty("operator")]
             public string @operator { get; set; }
           }
           [JsonProperty("case")]
-          public CourtCaseSelection @case { get; set; }
+          public CaseSelection @case { get; set; }
         }
       `);
     });
@@ -1105,24 +1105,108 @@ describe('C# Operations', () => {
       )) as Types.ComplexPluginOutput;
       expect(result.content).toBeSimilarStringTo(`
         public class Response {
-          public class PersonSelection {
+          public class MeSelection {
             [JsonProperty("name")]
             public string name { get; set; }
             [JsonProperty("age")]
             public int age { get; set; }
 
-            public class FriendSelection {
+            public class FriendsSelection {
               [JsonProperty("id")]
               public int id { get; set; }
             }
 
             [JsonProperty("friends")]
-            public System.Collections.Generic.List<FriendSelection> friends { get; set; }
+            public System.Collections.Generic.List<FriendsSelection> friends { get; set; }
           }
 
           [JsonProperty("me")]
-          public PersonSelection me { get; set; }
+          public MeSelection me { get; set; }
         }
+      `);
+    });
+
+    it('Should generate for duplicate fragments for same type', async () => {
+      const schema = buildSchema(/* GraphQL */ `
+        type Query {
+          gearSetup: GearSetup!
+        }
+        type GearSetup {
+          name: String!
+          primaryWeapon: Item!
+          secondaryWeapon: Item
+          classItem: Item
+        }
+        type Item {
+          id: Int!
+          name: String!
+        }
+      `);
+      const operation = parse(/* GraphQL */ `
+        fragment ItemFields on Item {
+          id
+          name
+        }
+
+        query Gear {
+          gearSetup {
+            primaryWeapon {
+              ...ItemFields
+            }
+            secondaryWeapon {
+              ...ItemFields
+            }
+            classItem {
+              ...ItemFields
+            }
+          }
+        }
+      `);
+      const result = (await plugin(
+        schema,
+        [{ location: '', document: operation }],
+        { typesafeOperation: true, memberNameConvention: 'pascalCase' },
+        { outputFile: '' },
+      )) as Types.ComplexPluginOutput;
+      expect(result.content).toBeSimilarStringTo(`
+        public class GearSetupSelection {
+          public class PrimaryWeaponSelection {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+
+            [JsonProperty("name")]
+            public string Name { get; set; }
+          }
+
+          [JsonProperty("primaryWeapon")]
+          public PrimaryWeaponSelection PrimaryWeapon { get; set; }
+
+          public class SecondaryWeaponSelection {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+
+            [JsonProperty("name")]
+            public string Name { get; set; }
+          }
+
+          [JsonProperty("secondaryWeapon")]
+          public SecondaryWeaponSelection SecondaryWeapon { get; set; }
+
+          public class ClassItemSelection {
+            [JsonProperty("id")]
+            public int Id { get; set; }
+
+            [JsonProperty("name")]
+            public string Name { get; set; }
+          }
+
+          [JsonProperty("classItem")]
+          public ClassItemSelection ClassItem { get; set; }
+        }
+
+        [JsonProperty("gearSetup")]
+        public GearSetupSelection GearSetup { get; set; }
+      }
       `);
     });
 
@@ -1164,7 +1248,7 @@ describe('C# Operations', () => {
           public string @record { get; set; }
         }
         public class Response {
-          public class CourtCaseSelection {
+          public class CaseSelection {
             [JsonProperty("private")]
             public string @private { get; set; }
             [JsonProperty("public")]
@@ -1173,7 +1257,7 @@ describe('C# Operations', () => {
             public string @operator { get; set; }
           }
           [JsonProperty("case")]
-          public CourtCaseSelection @case { get; set; }
+          public CaseSelection @case { get; set; }
         }
       `);
     });
@@ -1405,7 +1489,7 @@ describe('C# Operations', () => {
         { outputFile: '' },
       )) as Types.ComplexPluginOutput;
       expect(result.content).toBeSimilarStringTo(`
-        public class MyDataSelection {
+        public class MyQuerySelection {
           [JsonProperty("id")]
           public string Id { get; set; }
 


### PR DESCRIPTION
## Description

This PR prevents duplicate classes being generated by using the property named of the GQL type name as the basis for class name generation.

This will result in different class names, but it solves this issue.

Related # (issue)

#901

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)


## How Has This Been Tested?

This code is being used by us in production, where we have numerous fragments that was affected by the linked issue. I have updated the existing tests because it does change the name of the generated classes. 

Copilot helped update the tests, this was its summary of the changes.

Nested Response Classes have been changed from type-based naming to field-based naming:

PersonSelection → MeSelection (for the me field)
PersonSelection → YouSelection (for the you field)

Reserved Keyword Tests: Updated class names to use simplified naming:

CourtCaseSelection → CaseSelection

Fragment Response Classes: Updated fragment class names:

FriendSelection → FriendsSelection (for the friends field)
PersonSelection → MeSelection (for the me field)

Member Naming Convention Tests: Updated class names to reflect query structure:

MyDataSelection → MyQuerySelection

**Test Environment**:

- OS:
- `@graphql-codegen/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
