### PR TITLE
Add support for enum string values with data contract attributes

### DIFF
--- a/.changeset/clean-beers-bathe.md
+++ b/.changeset/clean-beers-bathe.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/c-sharp-operations': patch
+---
+
+Enhance accuracy of enum values by preserving schema case

--- a/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/src/visitor.ts
@@ -639,10 +639,17 @@ ${this._getOperationMethod(node)}
       .withName(convertSafeName(this.convertName(node.name)))
       .withBlock(
         indentMultiline(
-          node.values?.map(v => this._parsedConfig.memberNamingFunction(v.name.value)).join(',\n'),
+          node.values
+            ?.map(
+              v =>
+                `[EnumMember(Value = "${v.name.value}")]\n${this._parsedConfig.memberNamingFunction(v.name.value)}`,
+            )
+            .join(',\n'),
         ),
-      ).string;
+      );
 
-    return indentMultiline(enumDefinition, 2);
+    const enumWithAttributes = `[DataContract]\n[JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]\n${enumDefinition.string}`;
+
+    return indentMultiline(enumWithAttributes, 2);
   }
 }

--- a/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
+++ b/packages/plugins/c-sharp/c-sharp-operations/test/c-sharp-operations.spec.ts
@@ -1,6 +1,6 @@
-import { buildSchema, parse } from 'graphql';
 import { Types } from '@graphql-codegen/plugin-helpers';
 import '@graphql-codegen/testing';
+import { buildSchema, parse } from 'graphql';
 import { CSharpOperationsRawPluginConfig } from '../src/config.js';
 import { plugin } from '../src/index.js';
 
@@ -1276,6 +1276,7 @@ describe('C# Operations', () => {
           value2
           anotherValue
           LastValue
+          SHOUTY_SNAKE_VALUE
         }
       `);
       const operation = parse(/* GraphQL */ `
@@ -1291,11 +1292,19 @@ describe('C# Operations', () => {
         { outputFile: '' },
       )) as Types.ComplexPluginOutput;
       expect(result.content).toBeSimilarStringTo(`
+        [DataContract]
+        [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public enum MyEnum {
-           Value1,
-           Value2,
-           AnotherValue,
-           LastValue
+          [EnumMember(Value = "Value1")]
+          Value1,
+          [EnumMember(Value = "value2")]
+          Value2,
+          [EnumMember(Value = "anotherValue")]
+          AnotherValue,
+          [EnumMember(Value = "LastValue")]
+          LastValue,
+          [EnumMember(Value = "SHOUTY_SNAKE_VALUE")]
+          ShoutySnakeValue
         }
         `);
     });


### PR DESCRIPTION

## Description

This PR adds the data contract attributes for enum values to ensure the serialized strings are matching exactly what the schema expects. This is to support different value styles, per the linked issue.

Related # (issue)

#1161 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I updated the existing test case covering enums to include the attributes, and added a new value SHOUTY_SNAKE_VALUE.

I made a unit test on some C# code and verified that `Newtonsoft.Json` would accept `"value2"` as a string for the Value2 enum, however my example would not.

![image](https://github.com/user-attachments/assets/fc7e5e75-5e9d-413b-8104-409ad0058340)

The enum as generated by this PR

![image](https://github.com/user-attachments/assets/26cf6bfd-3634-4be5-a355-de7bd3e60490)

**Test Environment**:

- OS: Windows
- `@graphql-codegen/c-sharp-operations`: `3.1.1`
- NodeJS: 20.15.1

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The PR #1160 I just created adding `System.Text.Json` would break with this change. That would need to be updated to generate the equivalent attributes over there.