### PR TITLE
feat(typescript-react-apollo): export config type

### DIFF
--- a/packages/plugins/typescript/react-apollo/src/index.ts
+++ b/packages/plugins/typescript/react-apollo/src/index.ts
@@ -56,3 +56,5 @@ export const validate: PluginValidateFn<any> = async (
 };
 
 export { ReactApolloVisitor };
+
+export type { ReactApolloRawPluginConfig };


### PR DESCRIPTION
## Description

Export typescript-react-apollo's `ReactApolloRawPluginConfig` to enable strict typing in a GraphQL configuration module.

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1169

<!--
Don't use `Fixes` or `Fixed` to refer issues
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Something like this should work via a built package:

```js
/**
 * @returns {import('@graphql-codegen/typescript-react-apollo').ReactApolloRawPluginConfig}
 */
function createCodegenPluginConfig() {
```

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
