### PR TITLE
fix: use non-namespaced apollo-angular imports

### DIFF
--- a/.changeset/remove-angular-namespace.md
+++ b/.changeset/remove-angular-namespace.md
@@ -1,0 +1,5 @@
+---
+@graphql-codegen/typescript-apollo-angular: patch
+---
+
+Change `apollo-angular` imports to named non-namespace imports

--- a/packages/plugins/typescript/apollo-angular/src/visitor.ts
+++ b/packages/plugins/typescript/apollo-angular/src/visitor.ts
@@ -108,7 +108,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
       }
     }
 
-    const dependencyInjections = ['apollo: Apollo.Apollo'].concat(this.config.additionalDI);
+    const dependencyInjections = ['apollo: Apollo'].concat(this.config.additionalDI);
     const dependencyInjectionArgs = dependencyInjections.map(content => {
       return content.split(':')[0];
     });
@@ -129,7 +129,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
 
     const imports = [
       `import { Injectable } from '@angular/core';`,
-      `import * as Apollo from '${this.config.apolloAngularPackage}';`,
+      `import { Apollo, Query as ApolloQuery, Mutation as ApolloMutation } from '${this.config.apolloAngularPackage}';`,
     ];
 
     if (this.config.sdkClass) {
@@ -316,7 +316,7 @@ export class ApolloAngularVisitor extends ClientSideBaseVisitor<
   @Injectable({
     providedIn: ${this._providedIn(node)}
   })
-  export class ${serviceName} extends Apollo.${operationType}<${operationResultType}, ${operationVariablesTypes}> {
+  export class ${serviceName} extends Apollo${operationType}<${operationResultType}, ${operationVariablesTypes}> {
     ${this.config.addExplicitOverride ? 'override ' : ''}document = ${this._getDocumentNodeVariable(
       node,
       documentVariableName,

--- a/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
+++ b/packages/plugins/typescript/apollo-angular/tests/apollo-angular.spec.ts
@@ -84,7 +84,9 @@ describe('Apollo Angular', () => {
         },
       )) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Apollo from 'apollo-angular';`);
+      expect(content.prepend).toContain(
+        `import { Apollo, Query as ApolloQuery, Mutation as ApolloMutation } from 'apollo-angular';`,
+      );
       expect(content.prepend).toContain(`import { Injectable } from '@angular/core';`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -101,7 +103,7 @@ describe('Apollo Angular', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-          constructor(apollo: Apollo.Apollo) {
+          constructor(apollo: Apollo) {
             super(apollo);
           }
         }
@@ -123,7 +125,7 @@ describe('Apollo Angular', () => {
       )) as Types.ComplexPluginOutput;
 
       expect(content.content).toBeSimilarStringTo(`
-          constructor(apollo: Apollo.Apollo, testService: TestService, testService1: TestService1) {
+          constructor(apollo: Apollo, testService: TestService, testService1: TestService1) {
             super(apollo, testService, testService1);
           }
         }
@@ -163,7 +165,9 @@ describe('Apollo Angular', () => {
         },
       )) as Types.ComplexPluginOutput;
 
-      expect(content.prepend).toContain(`import * as Apollo from 'my-custom-apollo-angular';`);
+      expect(content.prepend).toContain(
+        `import { Apollo, Query as ApolloQuery, Mutation as ApolloMutation } from 'my-custom-apollo-angular';`,
+      );
       expect(content.prepend).toContain(`import { Injectable } from '@angular/core';`);
       await validateTypeScript(content, schema, docs, {});
     });
@@ -344,11 +348,15 @@ describe('Apollo Angular', () => {
     it('Should be able to use root schema object', async () => {
       const rootSchema = buildSchema(`
         type RootQuery { f: String }
-        schema { query: RootQuery }
+        type RootMutation { g(input: String!): String! }
+        schema { query: RootQuery, mutation: RootMutation }
       `);
       const query = gql`
         query test {
           f
+        }
+        mutation testMutation {
+          g(input: "foo")
         }
       `;
       const docs = [{ location: '', document: query }];
@@ -365,7 +373,13 @@ describe('Apollo Angular', () => {
         @Injectable({
           providedIn: 'root'
         })
-        export class TestGQL extends Apollo.Query
+        export class TestGQL extends ApolloQuery
+      `);
+      expect(content.content).toBeSimilarStringTo(`
+        @Injectable({
+          providedIn: 'root'
+        })
+        export class TestMutationGQL extends ApolloMutation
       `);
       await validateTypeScript(content, rootSchema, docs, {});
     });
@@ -756,10 +770,10 @@ describe('Apollo Angular', () => {
       expect(content.content).toBeSimilarStringTo(`@Injectable({
         providedIn: 'root'
       })
-      export class TestGQL extends Apollo.Query<TestQuery, TestQueryVariables> {
+      export class TestGQL extends ApolloQuery<TestQuery, TestQueryVariables> {
         document = Operations.TestDocument;
 
-        constructor(apollo: Apollo.Apollo) {
+        constructor(apollo: Apollo) {
           super(apollo);
         }
       }`);


### PR DESCRIPTION
## Description

Fixes a longstanding issue with being unable to write jest tests using generated services from `@graphql-codegen/typescript-apollo-angular`. The generated services file will now include:

```ts
import { Apollo, Query as ApolloQuery, Mutation as ApolloMutation } from 'apollo-angular';
```

instead of:

```ts
import * as Apollo from 'apollo-angular';
```

This was the suggested approach mentioned in #223 and #28 and seemed like a relatively straightforward fix that should have minimal impact on projects already using this library.

Related #223 and #28

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Without this fix in places, users that attempt to use generated service files in their jest tests will see the following error:

```sh
NG0202: This constructor is not compatible with Angular Dependency Injection because its dependency at index 0 of the parameter list is invalid. This can happen if the dependency type is a primitive like a string or if an ancestor of this class is missing an Angular decorator.
```

## How Has This Been Tested?

Up until this point I've been manually running a script to swap out the imports as part of codegen's `afterAllFileWrite` hook which gets rid of the issue.

**Test Environment**:

- OS: Mac OS 15.5
- `@graphql-codegen/typescript-apollo-angular`:
- NodeJS: 22.14.0

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

One other possible fix to this problem would be to address the namespace issue present in the `jest-preset-angular` plugin. There's an open issue around this issue:

https://github.com/thymikee/jest-preset-angular/issues/963

However I was unsure how to fix that library and the tweak to this library seemed far more straightforward.
