### PR TITLE
Fix missing perms

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,8 @@ jobs:
     uses: the-guild-org/shared-config/.github/workflows/release-stable.yml@main
     permissions:
       id-token: write # allows ODIC publishing
-      contents: write
+      pull-requests: write # allows creating Version Packages PR
+      contents: write # allows modifying changeset files
     with:
       releaseScript: release
       nodeVersion: 24


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/dotansimha/graphql-code-generator-community/pull/1371
The publish step seems to miss the permission to create PR. This PR adds it