### PR TITLE
Ignore vitest.config.ts from dep checks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,12 @@
     "import/no-extraneous-dependencies": [
       "error",
       {
-        "devDependencies": ["**/*.test.ts", "**/*.spec.ts", "**/test/**/*.ts"]
+        "devDependencies": [
+          "**/*.test.ts",
+          "**/*.spec.ts",
+          "**/test/**/*.ts",
+          "**/vitest.config.ts"
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Description

We are seeing lint issues [like this](https://github.com/dotansimha/graphql-code-generator-community/actions/runs/22813503438/job/66174434772) because `vitest.config.ts` is seen as business logic.

This PR excludes said file, similar to other test files