### PR TITLE
Bump codegen packages

### DIFF
--- a/.changeset/@graphql-codegen_c-sharp-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_c-sharp-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/c-sharp": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_c-sharp-common-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_c-sharp-common-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/c-sharp-common": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_c-sharp-operations-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_c-sharp-operations-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/c-sharp-operations": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_flutter-freezed-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_flutter-freezed-1444-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@graphql-codegen/flutter-freezed": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/schema-ast@^5.0.2` ↗︎](https://www.npmjs.com/package/@graphql-codegen/schema-ast/v/5.0.2) (from `^5.0.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_hasura-allow-list-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_hasura-allow-list-1444-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/hasura-allow-list": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)

--- a/.changeset/@graphql-codegen_import-types-preset-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_import-types-preset-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/import-types-preset": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_java-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_java-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/java": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_java-apollo-android-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_java-apollo-android-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/java-apollo-android": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_java-common-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_java-common-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/java-common": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_java-resolvers-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_java-resolvers-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/java-resolvers": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_jsdoc-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_jsdoc-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/jsdoc": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_kotlin-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_kotlin-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/kotlin": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_named-operations-object-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_named-operations-object-1444-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/named-operations-object": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)

--- a/.changeset/@graphql-codegen_near-operation-file-preset-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_near-operation-file-preset-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/near-operation-file-preset": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-apollo-angular-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-apollo-angular-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-apollo-angular": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-apollo-client-helpers-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-apollo-client-helpers-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-apollo-client-helpers": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-enum-array-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-enum-array-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-enum-array": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-generic-sdk-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-generic-sdk-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-generic-sdk": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-graphql-apollo-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-graphql-apollo-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-graphql-apollo": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-graphql-files-modules-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-graphql-files-modules-1444-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-graphql-files-modules": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-graphql-request-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-graphql-request-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-graphql-request": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-jit-sdk-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-jit-sdk-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-jit-sdk": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-mongodb-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-mongodb-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-mongodb": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-msw-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-msw-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-msw": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-nhost-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-nhost-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-nhost": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-oclif-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-oclif-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-oclif": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-react-apollo-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-react-apollo-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-react-apollo": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-react-offix-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-react-offix-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-react-offix": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-react-query-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-react-query-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-react-query": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-rtk-query-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-rtk-query-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-rtk-query": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-solid-query-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-solid-query-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-solid-query": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-stencil-apollo-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-stencil-apollo-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-stencil-apollo": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-urql-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-urql-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-urql": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-urql-graphcache-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-urql-graphcache-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-urql-graphcache": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-vue-apollo-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-vue-apollo-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-vue-apollo": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-vue-apollo-smart-ops-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-vue-apollo-smart-ops-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-vue-apollo-smart-ops": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_typescript-vue-urql-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-vue-urql-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-vue-urql": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/@graphql-codegen_urql-introspection-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_urql-introspection-1444-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/urql-introspection": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)

--- a/.changeset/@graphql-codegen_urql-svelte-operations-store-1444-dependencies.md
+++ b/.changeset/@graphql-codegen_urql-svelte-operations-store-1444-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/urql-svelte-operations-store": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/6.3.0) (from `^6.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^6.3.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/6.3.0) (from `^6.2.4`, in `dependencies`)

--- a/.changeset/chilly-candles-fold.md
+++ b/.changeset/chilly-candles-fold.md
@@ -1,0 +1,43 @@
+---
+'@graphql-codegen/urql-svelte-operations-store': patch
+'@graphql-codegen/named-operations-object': patch
+'@graphql-codegen/typescript-apollo-client-helpers': patch
+'@graphql-codegen/typescript-graphql-files-modules': patch
+'@graphql-codegen/typescript-vue-apollo-smart-ops': patch
+'@graphql-codegen/typescript-react-offix': patch
+'@graphql-codegen/c-sharp-operations': patch
+'@graphql-codegen/typescript-graphql-request': patch
+'@graphql-codegen/typescript-urql-graphcache': patch
+'@graphql-codegen/typescript-apollo-angular': patch
+'@graphql-codegen/typescript-graphql-apollo': patch
+'@graphql-codegen/typescript-stencil-apollo': patch
+'@graphql-codegen/urql-introspection': patch
+'@graphql-codegen/hasura-allow-list': patch
+'@graphql-codegen/typescript-react-apollo': patch
+'@graphql-codegen/c-sharp-common': patch
+'@graphql-codegen/typescript-generic-sdk': patch
+'@graphql-codegen/typescript-react-query': patch
+'@graphql-codegen/typescript-solid-query': patch
+'@graphql-codegen/typescript-enum-array': patch
+'@graphql-codegen/typescript-vue-apollo': patch
+'@graphql-codegen/flutter-freezed': patch
+'@graphql-codegen/typescript-rtk-query': patch
+'@graphql-codegen/java-apollo-android': patch
+'@graphql-codegen/typescript-vue-urql': patch
+'@graphql-codegen/near-operation-file-preset': patch
+'@graphql-codegen/typescript-jit-sdk': patch
+'@graphql-codegen/typescript-mongodb': patch
+'@graphql-codegen/typescript-nhost': patch
+'@graphql-codegen/typescript-oclif': patch
+'@graphql-codegen/c-sharp': patch
+'@graphql-codegen/typescript-urql': patch
+'@graphql-codegen/java-resolvers': patch
+'@graphql-codegen/typescript-msw': patch
+'@graphql-codegen/import-types-preset': patch
+'@graphql-codegen/java-common': patch
+'@graphql-codegen/kotlin': patch
+'@graphql-codegen/jsdoc': patch
+'@graphql-codegen/java': patch
+---
+
+Bump official codegen package deps

--- a/packages/plugins/c-sharp/c-sharp-common/package.json
+++ b/packages/plugins/c-sharp/c-sharp-common/package.json
@@ -35,8 +35,8 @@
     "graphql-tag": "2.12.6"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/c-sharp/c-sharp-operations/package.json
+++ b/packages/plugins/c-sharp/c-sharp-operations/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "@graphql-codegen/c-sharp-common": "2.0.0",
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/c-sharp/c-sharp/package.json
+++ b/packages/plugins/c-sharp/c-sharp/package.json
@@ -36,8 +36,8 @@
   },
   "dependencies": {
     "@graphql-codegen/c-sharp-common": "2.0.0",
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1",
     "unixify": "^1.0.0"

--- a/packages/plugins/dart/flutter-freezed/package.json
+++ b/packages/plugins/dart/flutter-freezed/package.json
@@ -44,9 +44,9 @@
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/schema-ast": "^5.0.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/schema-ast": "^5.0.2",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/java/apollo-android/package.json
+++ b/packages/plugins/java/apollo-android/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@graphql-codegen/java-common": "^4.0.0",
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "pluralize": "^8.0.0",

--- a/packages/plugins/java/common/package.json
+++ b/packages/plugins/java/common/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "min-indent": "1.0.1",
     "tslib": "^2.8.1",

--- a/packages/plugins/java/java/package.json
+++ b/packages/plugins/java/java/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@graphql-codegen/java-common": "^4.0.0",
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/plugins/java/kotlin/package.json
+++ b/packages/plugins/java/kotlin/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@graphql-codegen/java-common": "^4.0.0",
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/plugins/java/resolvers/package.json
+++ b/packages/plugins/java/resolvers/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@graphql-codegen/java-common": "^4.0.0",
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/plugins/other/hasura-allow-list/package.json
+++ b/packages/plugins/other/hasura-allow-list/package.json
@@ -39,7 +39,7 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
     "tslib": "^2.8.1",
     "yaml": "^1.10.2"
   },

--- a/packages/plugins/other/jsdoc/package.json
+++ b/packages/plugins/other/jsdoc/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/plugins/other/urql-introspection/package.json
+++ b/packages/plugins/other/urql-introspection/package.json
@@ -39,7 +39,7 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
     "@urql/introspection": "^0.3.2",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/typescript/apollo-angular/package.json
+++ b/packages/plugins/typescript/apollo-angular/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/apollo-client-helpers/package.json
+++ b/packages/plugins/typescript/apollo-client-helpers/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/enum-array/package.json
+++ b/packages/plugins/typescript/enum-array/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/plugins/typescript/generic-sdk/package.json
+++ b/packages/plugins/typescript/generic-sdk/package.json
@@ -40,8 +40,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/typescript/graphql-apollo/package.json
+++ b/packages/plugins/typescript/graphql-apollo/package.json
@@ -40,8 +40,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/graphql-files-modules/package.json
+++ b/packages/plugins/typescript/graphql-files-modules/package.json
@@ -39,7 +39,7 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
     "tslib": "^2.8.1"
   },
   "publishConfig": {

--- a/packages/plugins/typescript/graphql-request/package.json
+++ b/packages/plugins/typescript/graphql-request/package.json
@@ -41,8 +41,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/typescript/jit-sdk/package.json
+++ b/packages/plugins/typescript/jit-sdk/package.json
@@ -42,8 +42,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/typescript/mongodb/package.json
+++ b/packages/plugins/typescript/mongodb/package.json
@@ -40,9 +40,9 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
     "@graphql-codegen/typescript": "^5.0.9",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "@graphql-tools/utils": "^11.0.0",
     "auto-bind": "~4.0.0",
     "lodash": "^4.18.1",

--- a/packages/plugins/typescript/msw/package.json
+++ b/packages/plugins/typescript/msw/package.json
@@ -40,8 +40,8 @@
     "msw": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/named-operations-object/package.json
+++ b/packages/plugins/typescript/named-operations-object/package.json
@@ -40,7 +40,7 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/typescript/nhost/package.json
+++ b/packages/plugins/typescript/nhost/package.json
@@ -39,9 +39,9 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
     "@graphql-codegen/typescript": "^5.0.9",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "@urql/introspection": "^1.0.0",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/typescript/oclif/package.json
+++ b/packages/plugins/typescript/oclif/package.json
@@ -41,8 +41,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/typescript/react-apollo-offix/package.json
+++ b/packages/plugins/typescript/react-apollo-offix/package.json
@@ -40,8 +40,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15"
   },

--- a/packages/plugins/typescript/react-apollo/package.json
+++ b/packages/plugins/typescript/react-apollo/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/react-query/package.json
+++ b/packages/plugins/typescript/react-query/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/rtk-query/package.json
+++ b/packages/plugins/typescript/rtk-query/package.json
@@ -47,8 +47,8 @@
     }
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/solid-query/package.json
+++ b/packages/plugins/typescript/solid-query/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/stencil-apollo/package.json
+++ b/packages/plugins/typescript/stencil-apollo/package.json
@@ -41,8 +41,8 @@
     "stencil-apollo": "^0.1.3"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/urql-graphcache/package.json
+++ b/packages/plugins/typescript/urql-graphcache/package.json
@@ -41,8 +41,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/urql-svelte-operations-store/package.json
+++ b/packages/plugins/typescript/urql-svelte-operations-store/package.json
@@ -40,8 +40,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/urql/package.json
+++ b/packages/plugins/typescript/urql/package.json
@@ -40,8 +40,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "tslib": "^2.8.1"
   },

--- a/packages/plugins/typescript/vue-apollo-smart-ops/package.json
+++ b/packages/plugins/typescript/vue-apollo-smart-ops/package.json
@@ -40,8 +40,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/vue-apollo/package.json
+++ b/packages/plugins/typescript/vue-apollo/package.json
@@ -40,8 +40,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/vue-urql/package.json
+++ b/packages/plugins/typescript/vue-urql/package.json
@@ -40,8 +40,8 @@
     "graphql-tag": "^2.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/presets/import-types/package.json
+++ b/packages/presets/import-types/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@graphql-codegen/add": "^6.0.0",
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "tslib": "^2.8.1"
   },
   "publishConfig": {

--- a/packages/presets/near-operation-file/package.json
+++ b/packages/presets/near-operation-file/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@graphql-codegen/add": "^6.0.0",
-    "@graphql-codegen/plugin-helpers": "^6.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-codegen/plugin-helpers": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
     "@graphql-tools/utils": "^11.0.0",
     "parse-filepath": "^1.0.2",
     "tslib": "^2.8.1"


### PR DESCRIPTION
## Description

We recently bumped package versions of official Codegen CLI and shared deps.
This results in a mismatch in types if the latest CLI version is installed, but the shared dep versions are not updated. Related: https://github.com/eddeee888/graphql-code-generator-plugins/issues/428 

This PR bumps versions of shared packages (if they are already on v6) so users won't have to do this manually (or they may see type issues).