### PR TITLE
Deduplicate external fragments in near-operation-file preset

### DIFF
--- a/.changeset/funny-jokes-joke.md
+++ b/.changeset/funny-jokes-joke.md
@@ -1,0 +1,10 @@
+---
+'@graphql-codegen/near-operation-file-preset': patch
+---
+
+Deduplicate `externalFragments` by name when multiple source documents are merged into the same generated output
+
+Why: multiple documents can resolve to the same generated file and each contribute the same external fragment
+downstream plugins then receive repeated externalFragments, which can cause severe perf blow-ups
+
+Relates to: https://github.com/dotansimha/graphql-code-generator-community/issues/752

--- a/packages/presets/near-operation-file/src/index.ts
+++ b/packages/presets/near-operation-file/src/index.ts
@@ -325,7 +325,16 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
     const artifacts: Array<Types.GenerateOptions> = [];
 
     for (const [filename, record] of filePathsMap.entries()) {
+      const fragmentNames = new Set<string>();
       let fragmentImportsArr = record.fragmentImports;
+      const externalFragments = record.externalFragments.filter(fragment => {
+        if (fragmentNames.has(fragment.name)) {
+          return false;
+        }
+
+        fragmentNames.add(fragment.name);
+        return true;
+      });
 
       if (importAllFragmentsFrom) {
         fragmentImportsArr = record.fragmentImports.map<ImportDeclaration<FragmentImport>>(t => {
@@ -377,7 +386,7 @@ export const preset: Types.OutputPreset<NearOperationFileConfig> = {
         // are exported from operations file
         exportFragmentSpreadSubTypes: true,
         namespacedImportName: importTypesNamespace,
-        externalFragments: record.externalFragments,
+        externalFragments,
         fragmentImports: fragmentImportsArr,
       };
 

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -85,6 +85,53 @@ describe('near-operation-file preset', () => {
   ];
 
   describe('Issues', () => {
+    it('dedupes repeated external fragments when multiple documents are merged into the same output file', async () => {
+      const result = await executePreset({
+        baseOutputDir: './src/',
+        config: {},
+        presetConfig: {
+          cwd: '/some/deep/path',
+          baseTypesPath: 'types.ts',
+          fileName: 'types',
+        },
+        schemaAst: schemaNode,
+        schema: getCachedDocumentNodeFromSchema(schemaNode),
+        documents: [
+          {
+            location: '/some/deep/path/src/graphql/query-a.graphql',
+            document: parse(/* GraphQL */ `
+              query QueryA {
+                user {
+                  ...UserFields
+                }
+              }
+            `),
+          },
+          {
+            location: '/some/deep/path/src/graphql/query-b.graphql',
+            document: parse(/* GraphQL */ `
+              query QueryB {
+                user {
+                  ...UserFields
+                }
+              }
+            `),
+          },
+          {
+            location: '/some/deep/path/src/graphql/user-fragment.graphql',
+            document: fragmentAst,
+          },
+        ],
+        plugins: [],
+        pluginMap: {},
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].filename).toBe('/some/deep/path/src/graphql/types.generated.ts');
+      expect(result[0].config.externalFragments).toHaveLength(1);
+      expect(result[0].config.externalFragments[0].name).toBe('UserFields');
+    });
+
     it('#5002 - error when inline fragment does not specify the name of the type', async () => {
       const testSchema = parse(/* GraphQL */ `
         scalar Date


### PR DESCRIPTION
This deduplicates `externalFragments` by name in `near-operation-file` when multiple source documents are merged into the same generated output.

Why:
- multiple documents can resolve to the same generated file and each contribute the same external fragment
- downstream plugins then receive repeated `externalFragments`, which can cause severe perf blow-ups

This is related to dotansimha/graphql-code-generator-community#752 and supersedes the narrower consumer-side fix I initially opened in dotansimha/graphql-code-generator#10728.

Validation:
- added a regression test that merges two documents into the same generated output and asserts `externalFragments` are deduped

Downstream benchmark from the original report:
- before: ~248s
- after dedupe: ~2s
