### PR TITLE
[typescript-rtk-query] Fix TypedDocumentString issue

### DIFF
--- a/.changeset/@graphql-codegen_typescript-rtk-query-1496-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-rtk-query-1496-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-rtk-query": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^7.0.1` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/7.0.1) (from `^6.3.0`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^7.1.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/7.1.0) (from `^6.3.0`, in `dependencies`)

--- a/.changeset/dirty-donkeys-start.md
+++ b/.changeset/dirty-donkeys-start.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-rtk-query': patch
+---
+
+Fix missing TypedDocumentString support

--- a/packages/plugins/typescript/rtk-query/package.json
+++ b/packages/plugins/typescript/rtk-query/package.json
@@ -47,8 +47,8 @@
     }
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.3.0",
-    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+    "@graphql-codegen/plugin-helpers": "^7.0.1",
+    "@graphql-codegen/visitor-plugin-common": "^7.1.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/rtk-query/src/index.ts
+++ b/packages/plugins/typescript/rtk-query/src/index.ts
@@ -1,7 +1,7 @@
 import { extname } from 'path';
 import { concatAST, FragmentDefinitionNode, GraphQLSchema, Kind } from 'graphql';
 import { oldVisit, PluginFunction, PluginValidateFn, Types } from '@graphql-codegen/plugin-helpers';
-import { LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
+import { LoadedFragment, typedDocumentString } from '@graphql-codegen/visitor-plugin-common';
 import { RTKQueryRawPluginConfig } from './config.js';
 import { RTKQueryVisitor } from './visitor.js';
 
@@ -32,6 +32,7 @@ export const plugin: PluginFunction<RTKQueryRawPluginConfig, Types.ComplexPlugin
   return {
     prepend: visitor.getImports(),
     content: [
+      typedDocumentString.template,
       visitor.fragments,
       ...visitorResult.definitions.filter(t => typeof t === 'string'),
       visitor.getInjectCall(),

--- a/packages/plugins/typescript/rtk-query/src/visitor.ts
+++ b/packages/plugins/typescript/rtk-query/src/visitor.ts
@@ -7,6 +7,7 @@ import {
   DocumentMode,
   getConfigValue,
   LoadedFragment,
+  typedDocumentString,
 } from '@graphql-codegen/visitor-plugin-common';
 import { RTKQueryPluginConfig, RTKQueryRawPluginConfig } from './config.js';
 
@@ -55,8 +56,15 @@ export class RTKQueryVisitor extends ClientSideBaseVisitor<
       return baseImports;
     }
 
+    const typedDocumentStringPropImport = this._generateImport(
+      typedDocumentString.import,
+      typedDocumentString.import.propName,
+      true,
+    );
+
     return [
       ...baseImports,
+      typedDocumentStringPropImport,
       `import { ${this.config.importBaseApiAlternateName} } from '${this.config.importBaseApiFrom}';`,
     ];
   }

--- a/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
+++ b/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
@@ -1,7 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`RTK Query > For fragment 1`] = `
-"export const VoteButtonsFragmentDoc = new TypedDocumentString(\`
+"export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
+export const VoteButtonsFragmentDoc = new TypedDocumentString(\`
     fragment VoteButtons on Entry {
   score
   vote {
@@ -13,7 +31,25 @@ exports[`RTK Query > For fragment 1`] = `
 `;
 
 exports[`RTK Query > With addTransformResponse 1`] = `
-"
+"export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
+
 export const CommentDocument = new TypedDocumentString(\`
     query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
   currentUser {
@@ -85,7 +121,25 @@ export { injectedRtkApi as api };
 `;
 
 exports[`RTK Query > With hooks 1`] = `
-"
+"export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
+
 export const CommentDocument = new TypedDocumentString(\`
     query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
   currentUser {
@@ -154,7 +208,25 @@ export const { useCommentQuery, useLazyCommentQuery, useFeedQuery, useLazyFeedQu
 `;
 
 exports[`RTK Query > With importBaseApiAlternateName 1`] = `
-"
+"export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
+
 export const CommentDocument = new TypedDocumentString(\`
     query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
   currentUser {
@@ -223,7 +295,25 @@ export { injectedRtkApi as api };
 `;
 
 exports[`RTK Query > With overrideExisting 1`] = `
-"
+"export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
+
 export const CommentDocument = new TypedDocumentString(\`
     query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
   currentUser {
@@ -293,7 +383,112 @@ export { injectedRtkApi as api };
 `;
 
 exports[`RTK Query > Without hooks 1`] = `
+"export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
+
+export const CommentDocument = new TypedDocumentString(\`
+    query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
+  currentUser {
+    login
+    html_url
+  }
+  entry(repoFullName: $repoFullName) {
+    id
+    postedBy {
+      login
+      html_url
+    }
+    createdAt
+    comments(limit: $limit, offset: $offset) {
+      ...CommentsPageComment
+    }
+    commentCount
+    repository {
+      full_name
+      html_url
+      ... on Repository {
+        description
+        open_issues_count
+        stargazers_count
+      }
+    }
+  }
+}
+    \`);
+export const FeedDocument = new TypedDocumentString(\`
+    query Feed($type: FeedType!, $offset: Int, $limit: Int) {
+  currentUser {
+    login
+  }
+  feed(type: $type, offset: $offset, limit: $limit) {
+    ...FeedEntry
+  }
+}
+    \`);
+export const SubmitRepositoryDocument = new TypedDocumentString(\`
+    mutation submitRepository($repoFullName: String!) {
+  submitRepository(repoFullName: $repoFullName) {
+    createdAt
+  }
+}
+    \`);
+
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    Comment: build.query<CommentQuery, CommentQueryVariables>({
+      query: (variables) => ({ document: CommentDocument, variables })
+    }),
+    Feed: build.query<FeedQuery, FeedQueryVariables>({
+      query: (variables) => ({ document: FeedDocument, variables })
+    }),
+    submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
+      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
+    }),
+  }),
+});
+
+export { injectedRtkApi as api };
+
+
 "
+`;
+
+exports[`RTK Query > Without hooks 2`] = `
+"export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
+
 export const CommentDocument = new TypedDocumentString(\`
     query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
   currentUser {

--- a/packages/plugins/typescript/rtk-query/tests/rtk-query.spec.ts
+++ b/packages/plugins/typescript/rtk-query/tests/rtk-query.spec.ts
@@ -45,6 +45,9 @@ describe('RTK Query', () => {
       },
     )) as Types.ComplexPluginOutput;
 
+    expect(content.prepend).toContain(
+      "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
+    );
     expect(content.prepend).toContain("import { api } from './baseApi';");
 
     expect(content.content).toMatchSnapshot();
@@ -66,6 +69,9 @@ describe('RTK Query', () => {
       },
     )) as Types.ComplexPluginOutput;
 
+    expect(content.prepend).toContain(
+      "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
+    );
     expect(content.prepend).toContain("import { api } from './baseApi';");
 
     expect(content.content).toMatchSnapshot();
@@ -88,6 +94,9 @@ describe('RTK Query', () => {
       },
     )) as Types.ComplexPluginOutput;
 
+    expect(content.prepend).toContain(
+      "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
+    );
     expect(content.prepend).toContain("import { api } from './baseApi';");
     expect(content.content).toContain('overrideExisting: module.hot?.status() === "apply",');
 
@@ -110,6 +119,9 @@ describe('RTK Query', () => {
       },
     )) as Types.ComplexPluginOutput;
 
+    expect(content.prepend).toContain(
+      "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
+    );
     expect(content.prepend).toContain("import { alternateApiName } from './baseApi';");
     expect(content.content).toContain('alternateApiName.injectEndpoints');
 
@@ -131,6 +143,10 @@ describe('RTK Query', () => {
         outputFile: 'graphql.ts',
       },
     )) as Types.ComplexPluginOutput;
+
+    expect(content.prepend).toContain(
+      "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
+    );
 
     expect(content.content).toContain('transformResponse: (response: CommentQuery) => response');
     expect(content.content).toContain('transformResponse: (response: FeedQuery) => response');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,6 +1597,22 @@
     parse-filepath "^1.0.2"
     tslib "^2.8.0"
 
+"@graphql-codegen/visitor-plugin-common@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.1.0.tgz#73aaf4aa2ce72255e687348d311f8aa26749dfb1"
+  integrity sha512-CO4fJyflbYBuAwbQD16bAuWBIXkz9il3JwyC+pQzXh8NJ+BZZDXmYjmVeGeJuoMUIQDb+CNo2thCU0bFFamAkg==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^7.0.1"
+    "@graphql-tools/optimize" "^2.0.0"
+    "@graphql-tools/relay-operation-optimizer" "^7.1.1"
+    "@graphql-tools/utils" "^11.0.0"
+    auto-bind "^5.0.0"
+    change-case-all "^2.1.0"
+    dependency-graph "^1.0.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "^2.8.0"
+
 "@graphql-hive/signal@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-hive/signal/-/signal-2.0.0.tgz#205805328b118e1ae556417ed364257234800464"


### PR DESCRIPTION
## Description

This PR fixes `@graphql-codegen/typescript-rtk-query` to correctly set up and use `TypedDocumentString`.

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1410

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test
