### PR TITLE
[typescript-react-query] Fix TypedDocumentString issue

### DIFF
--- a/.changeset/@graphql-codegen_typescript-react-query-1497-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-react-query-1497-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-codegen/typescript-react-query": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/plugin-helpers@^7.0.1` ↗︎](https://www.npmjs.com/package/@graphql-codegen/plugin-helpers/v/7.0.1) (from `^6.3.0`, in `dependencies`)
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^7.1.0` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/7.1.0) (from `^6.3.0`, in `dependencies`)

--- a/.changeset/wet-dancers-lose.md
+++ b/.changeset/wet-dancers-lose.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Fix missing TypedDocumentString support

--- a/packages/plugins/typescript/react-query/package.json
+++ b/packages/plugins/typescript/react-query/package.json
@@ -39,8 +39,8 @@
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^6.3.0",
-    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+    "@graphql-codegen/plugin-helpers": "^7.0.1",
+    "@graphql-codegen/visitor-plugin-common": "^7.1.0",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/react-query/src/index.ts
+++ b/packages/plugins/typescript/react-query/src/index.ts
@@ -1,7 +1,7 @@
 import { extname } from 'path';
 import { concatAST, FragmentDefinitionNode, GraphQLSchema, Kind } from 'graphql';
 import { oldVisit, PluginFunction, PluginValidateFn, Types } from '@graphql-codegen/plugin-helpers';
-import { LoadedFragment } from '@graphql-codegen/visitor-plugin-common';
+import { LoadedFragment, typedDocumentString } from '@graphql-codegen/visitor-plugin-common';
 import { ReactQueryRawPluginConfig } from './config.js';
 import { ReactQueryVisitor } from './visitor.js';
 
@@ -34,6 +34,7 @@ export const plugin: PluginFunction<ReactQueryRawPluginConfig, Types.ComplexPlug
       prepend: [...visitor.getImports(), visitor.getFetcherImplementation()],
       content: [
         '',
+        typedDocumentString.template,
         visitor.fragments,
         ...visitorResult.definitions.filter(t => typeof t === 'string'),
       ].join('\n'),

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -8,6 +8,7 @@ import {
   DocumentMode,
   getConfigValue,
   LoadedFragment,
+  typedDocumentString,
 } from '@graphql-codegen/visitor-plugin-common';
 import { BaseReactQueryPluginConfig, ReactQueryRawPluginConfig } from './config.js';
 import { CustomMapperFetcher } from './fetcher-custom-mapper.js';
@@ -100,7 +101,17 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
         ? 'react-query'
         : '@tanstack/react-query';
 
-    return [...baseImports, `import { ${hookAndTypeImports.join(', ')} } from '${moduleName}';`];
+    const typedDocumentStringPropImport = this._generateImport(
+      typedDocumentString.import,
+      typedDocumentString.import.propName,
+      true,
+    );
+
+    return [
+      ...baseImports,
+      typedDocumentStringPropImport,
+      `import { ${hookAndTypeImports.join(', ')} } from '${moduleName}';`,
+    ];
   }
 
   public getFetcherImplementation(): string {

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -2,6 +2,24 @@
 
 exports[`React-Query > exposeQueryKeys: true > Should generate getKey for each query 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -62,6 +80,24 @@ export const useTestMutation = <
 
 exports[`React-Query > exposeQueryKeys: true, addInfiniteQuery: true > Should generate getKey for each query - also infinite queries 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -139,6 +175,24 @@ export const useTestMutation = <
 
 exports[`React-Query > exposeQueryRootKeys: true > Should generate rootKey for each query 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -199,6 +253,24 @@ export const useTestMutation = <
 
 exports[`React-Query > exposeQueryRootKeys: true, addInfiniteQuery: true > Should generate rootKey for each query - also infinite queries 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -276,6 +348,24 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: custom-mapper > Should generate mutation correctly with lazy variables > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -344,6 +434,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: custom-mapper > Should generate mutation correctly with lazy variables > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions } from 'react-query';",
   "import { useCustomFetcher } from './my-file';",
 ]
@@ -351,6 +442,24 @@ exports[`React-Query > fetcher: custom-mapper > Should generate mutation correct
 
 exports[`React-Query > fetcher: custom-mapper > Should generate query correctly with external mapper > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -419,6 +528,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: custom-mapper > Should generate query correctly with external mapper > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions } from 'react-query';",
   "import { myCustomFetcher } from './my-file';",
 ]
@@ -426,6 +536,24 @@ exports[`React-Query > fetcher: custom-mapper > Should generate query correctly 
 
 exports[`React-Query > fetcher: custom-mapper > Should generate query correctly with internal mapper > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -480,6 +608,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: custom-mapper > Should generate query correctly with internal mapper > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';",
   null,
 ]
@@ -487,6 +616,24 @@ exports[`React-Query > fetcher: custom-mapper > Should generate query correctly 
 
 exports[`React-Query > fetcher: fetch > Should generate query and mutation correctly > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -545,6 +692,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: fetch > Should generate query and mutation correctly > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';",
   "
 function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {
@@ -571,6 +719,24 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
 
 exports[`React-Query > fetcher: graphql-request > Should generate query correctly with client > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -649,6 +815,7 @@ exports[`React-Query > fetcher: graphql-request > Should generate query correctl
 [
   "import { GraphQLClient } from 'graphql-request';",
   "import { RequestInit } from 'graphql-request/dist/types.dom';",
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions } from 'react-query';",
   "
 function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
@@ -663,6 +830,24 @@ function fetcher<TData, TVariables extends { [key: string]: any }>(client: Graph
 
 exports[`React-Query > fetcher: graphql-request with clientImportPath > Should generate query correctly with client > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -724,6 +909,7 @@ exports[`React-Query > fetcher: graphql-request with clientImportPath > Should g
   "import { client as graphqlClient } from 'client.ts';",
   "import { GraphQLClient } from 'graphql-request';",
   "import { RequestInit } from 'graphql-request/dist/types.dom';",
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';",
   "
 function fetcher<TData, TVariables extends { [key: string]: any }>(query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
@@ -738,6 +924,24 @@ function fetcher<TData, TVariables extends { [key: string]: any }>(query: string
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with fetch config > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -792,6 +996,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with fetch config > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
@@ -818,6 +1023,24 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with fetch config and fetchParams object > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -872,6 +1095,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with fetch config and fetchParams object > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
@@ -898,6 +1122,24 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with hardcoded endpoint > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -966,6 +1208,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with hardcoded endpoint > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions } from 'react-query';",
   "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
@@ -991,6 +1234,24 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with hardcoded endpoint from env var > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -1045,6 +1306,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with hardcoded endpoint from env var > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
@@ -1070,6 +1332,24 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with hardcoded endpoint from just identifier > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -1124,6 +1404,7 @@ export const useTestMutation = <
 
 exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctly with hardcoded endpoint from just identifier > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
 function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
@@ -1149,6 +1430,7 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
 
 exports[`React-Query > reactQueryImportFrom: custom-path > Should import react-query from custom path > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'custom-react-query';",
   "
 function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {
@@ -1175,6 +1457,24 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
 
 exports[`React-Query > support import-type preset in v4 > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -1233,6 +1533,24 @@ export const useTestMutation = <
 
 exports[`React-Query > support import-type preset in v5 > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -1295,6 +1613,24 @@ export const useTestMutation = <
 
 exports[`React-Query > support v4 syntax > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -1368,6 +1704,7 @@ export const useTestMutation = <
 
 exports[`React-Query > support v4 syntax > prepend 1`] = `
 [
+  "import type { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useInfiniteQuery, useMutation, type UseQueryOptions, type UseInfiniteQueryOptions, type UseMutationOptions } from '@tanstack/react-query';",
   "
 function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {
@@ -1394,6 +1731,24 @@ function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, 
 
 exports[`React-Query > support v5 syntax > content 1`] = `
 "
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 
 export const TestDocument = new TypedDocumentString(\`
     query test {
@@ -1513,6 +1868,7 @@ export const useTestMutation = <
 
 exports[`React-Query > support v5 syntax > prepend 1`] = `
 [
+  "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useSuspenseQuery, useInfiniteQuery, useSuspenseInfiniteQuery, useMutation, UseQueryOptions, UseSuspenseQueryOptions, UseInfiniteQueryOptions, InfiniteData, UseSuspenseInfiniteQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
 function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {


### PR DESCRIPTION
## Description

This PR fixes @graphql-codegen/typescript-react-query to correctly set up and use TypedDocumentString.

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1410

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test