### PR TITLE
[typescript-rtk-query][typescript-react-query] Handle TypedDocumentString type wireup to avoid manual typing

### DIFF
--- a/.changeset/afraid-tips-jump.md
+++ b/.changeset/afraid-tips-jump.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Fix document type overriding to ensure TypeScript works without manual typing

--- a/.changeset/good-flies-marry.md
+++ b/.changeset/good-flies-marry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-rtk-query': patch
+---
+
+Fix document type overriding to ensure TypeScript works without manual typing

--- a/dev-test/githunt/types.react-query.ts
+++ b/dev-test/githunt/types.react-query.ts
@@ -1,3 +1,4 @@
+import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';
 import {
   useInfiniteQuery,
   UseInfiniteQueryOptions,
@@ -22,7 +23,7 @@ export type Incremental<T> =
 function fetcher<TData, TVariables>(
   endpoint: string,
   requestInit: RequestInit,
-  query: string,
+  query: TypedDocumentString<unknown, unknown>,
   variables?: TVariables,
 ) {
   return async (): Promise<TData> => {
@@ -375,6 +376,24 @@ export type VoteMutation = {
   } | null;
 };
 
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 export const CommentsPageCommentFragmentDoc = new TypedDocumentString(
   `
     fragment CommentsPageComment on Comment {

--- a/dev-test/githunt/types.rtk-query.ts
+++ b/dev-test/githunt/types.rtk-query.ts
@@ -1,3 +1,4 @@
+import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';
 import { api } from '../../packages/plugins/typescript/rtk-query/tests/baseApi';
 
 module.hot?.accept();
@@ -344,6 +345,24 @@ export type VoteMutation = {
   } | null;
 };
 
+export class TypedDocumentString<TResult, TVariables>
+  extends String
+  implements DocumentTypeDecoration<TResult, TVariables>
+{
+  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+  private value: string;
+  public __meta__?: Record<string, any> | undefined;
+
+  constructor(value: string, __meta__?: Record<string, any> | undefined) {
+    super(value);
+    this.value = value;
+    this.__meta__ = __meta__;
+  }
+
+  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+    return this.value;
+  }
+}
 export const CommentsPageCommentFragmentDoc = new TypedDocumentString(
   `
     fragment CommentsPageComment on Comment {
@@ -557,25 +576,28 @@ const injectedRtkApi = api.injectEndpoints({
   overrideExisting: module.hot?.status() === 'apply',
   endpoints: build => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: variables => ({ document: CommentDocument, variables }),
+      query: variables => ({ document: CommentDocument as unknown as string, variables }),
     }),
     CurrentUserForProfile: build.query<
       CurrentUserForProfileQuery,
       CurrentUserForProfileQueryVariables | void
     >({
-      query: variables => ({ document: CurrentUserForProfileDocument, variables }),
+      query: variables => ({
+        document: CurrentUserForProfileDocument as unknown as string,
+        variables,
+      }),
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: variables => ({ document: FeedDocument, variables }),
+      query: variables => ({ document: FeedDocument as unknown as string, variables }),
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: variables => ({ document: SubmitRepositoryDocument, variables }),
+      query: variables => ({ document: SubmitRepositoryDocument as unknown as string, variables }),
     }),
     submitComment: build.mutation<SubmitCommentMutation, SubmitCommentMutationVariables>({
-      query: variables => ({ document: SubmitCommentDocument, variables }),
+      query: variables => ({ document: SubmitCommentDocument as unknown as string, variables }),
     }),
     vote: build.mutation<VoteMutation, VoteMutationVariables>({
-      query: variables => ({ document: VoteDocument, variables }),
+      query: variables => ({ document: VoteDocument as unknown as string, variables }),
     }),
   }),
 });

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch-hardcoded.ts
@@ -39,7 +39,7 @@ export class HardcodedFetchFetcher extends FetcherRenderer {
 
   generateFetcherImplementation(): string {
     return `
-function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch(${this.getEndpoint()}, {
 ${this.getFetchParams()}

--- a/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-fetch.ts
@@ -10,7 +10,7 @@ export class FetchFetcher extends FetcherRenderer {
 
   generateFetcherImplementation(): string {
     return `
-function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch(endpoint, {
       method: 'POST',

--- a/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
+++ b/packages/plugins/typescript/react-query/src/fetcher-graphql-request.ts
@@ -18,7 +18,7 @@ export class GraphQLRequestClientFetcher extends FetcherRenderer {
   generateFetcherImplementation(): string {
     return this.clientPath
       ? `
-function fetcher<TData, TVariables extends { [key: string]: any }>(query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
+function fetcher<TData, TVariables extends { [key: string]: any }>(query: TypedDocumentString<unknown, unknown>, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
   return async (): Promise<TData> => graphqlClient.request({
     document: query,
     variables,
@@ -26,7 +26,7 @@ function fetcher<TData, TVariables extends { [key: string]: any }>(query: string
   });
 }`
       : `
-function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
+function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: TypedDocumentString<unknown, unknown>, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
   return async (): Promise<TData> => client.request({
     document: query,
     variables,

--- a/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
+++ b/packages/plugins/typescript/react-query/tests/__snapshots__/react-query.spec.ts.snap
@@ -695,7 +695,7 @@ exports[`React-Query > fetcher: fetch > Should generate query and mutation corre
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';",
   "
-function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch(endpoint, {
       method: 'POST',
@@ -818,7 +818,7 @@ exports[`React-Query > fetcher: graphql-request > Should generate query correctl
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions } from 'react-query';",
   "
-function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
+function fetcher<TData, TVariables extends { [key: string]: any }>(client: GraphQLClient, query: TypedDocumentString<unknown, unknown>, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
   return async (): Promise<TData> => client.request({
     document: query,
     variables,
@@ -912,7 +912,7 @@ exports[`React-Query > fetcher: graphql-request with clientImportPath > Should g
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';",
   "
-function fetcher<TData, TVariables extends { [key: string]: any }>(query: string, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
+function fetcher<TData, TVariables extends { [key: string]: any }>(query: TypedDocumentString<unknown, unknown>, variables?: TVariables, requestHeaders?: RequestInit['headers']) {
   return async (): Promise<TData> => graphqlClient.request({
     document: query,
     variables,
@@ -999,7 +999,7 @@ exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctl
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
-function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch("http://localhost:3000/graphql", {
     method: "POST",
@@ -1098,7 +1098,7 @@ exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctl
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
-function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch("http://localhost:3000/graphql", {
     method: "POST",
@@ -1211,7 +1211,7 @@ exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctl
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useInfiniteQuery, useMutation, UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions } from 'react-query';",
   "
-function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch("http://localhost:3000/graphql", {
     method: "POST",
@@ -1309,7 +1309,7 @@ exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctl
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
-function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch(process.env.ENDPOINT_URL as string, {
     method: "POST",
@@ -1407,7 +1407,7 @@ exports[`React-Query > fetcher: hardcoded-fetch > Should generate query correctl
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
-function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch(myEndpoint as string, {
     method: "POST",
@@ -1433,7 +1433,7 @@ exports[`React-Query > reactQueryImportFrom: custom-path > Should import react-q
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'custom-react-query';",
   "
-function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch(endpoint, {
       method: 'POST',
@@ -1707,7 +1707,7 @@ exports[`React-Query > support v4 syntax > prepend 1`] = `
   "import type { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useInfiniteQuery, useMutation, type UseQueryOptions, type UseInfiniteQueryOptions, type UseMutationOptions } from '@tanstack/react-query';",
   "
-function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch(endpoint, {
       method: 'POST',
@@ -1871,7 +1871,7 @@ exports[`React-Query > support v5 syntax > prepend 1`] = `
   "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
   "import { useQuery, useSuspenseQuery, useInfiniteQuery, useSuspenseInfiniteQuery, useMutation, UseQueryOptions, UseSuspenseQueryOptions, UseInfiniteQueryOptions, InfiniteData, UseSuspenseInfiniteQueryOptions, UseMutationOptions } from '@tanstack/react-query';",
   "
-function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: string, variables?: TVariables) {
+function fetcher<TData, TVariables>(endpoint: string, requestInit: RequestInit, query: TypedDocumentString<unknown, unknown>, variables?: TVariables) {
   return async (): Promise<TData> => {
     const res = await fetch(endpoint, {
       method: 'POST',

--- a/packages/plugins/typescript/rtk-query/src/visitor.ts
+++ b/packages/plugins/typescript/rtk-query/src/visitor.ts
@@ -131,7 +131,7 @@ export { injectedRtkApi as api };
     const operationTypeString = operationType.toLowerCase();
 
     const functionsString =
-      `query: (variables) => ({ document: ${documentVariableName} unknown as string, variables })
+      `query: (variables) => ({ document: ${documentVariableName} as unknown as string, variables })
       ${this.injectTransformResponse(Generics)}`.trim();
 
     const endpointString = `

--- a/packages/plugins/typescript/rtk-query/src/visitor.ts
+++ b/packages/plugins/typescript/rtk-query/src/visitor.ts
@@ -131,7 +131,7 @@ export { injectedRtkApi as api };
     const operationTypeString = operationType.toLowerCase();
 
     const functionsString =
-      `query: (variables) => ({ document: ${documentVariableName}, variables })
+      `query: (variables) => ({ document: ${documentVariableName} unknown as string, variables })
       ${this.injectTransformResponse(Generics)}`.trim();
 
     const endpointString = `

--- a/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
+++ b/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
@@ -100,15 +100,15 @@ export const SubmitRepositoryDocument = new TypedDocumentString(\`
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument unknown as string, variables })
+      query: (variables) => ({ document: CommentDocument as unknown as string, variables })
       transformResponse: (response: CommentQuery) => response
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument unknown as string, variables })
+      query: (variables) => ({ document: FeedDocument as unknown as string, variables })
       transformResponse: (response: FeedQuery) => response
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument as unknown as string, variables })
       transformResponse: (response: SubmitRepositoryMutation) => response
     }),
   }),
@@ -190,13 +190,13 @@ export const SubmitRepositoryDocument = new TypedDocumentString(\`
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument unknown as string, variables })
+      query: (variables) => ({ document: CommentDocument as unknown as string, variables })
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument unknown as string, variables })
+      query: (variables) => ({ document: FeedDocument as unknown as string, variables })
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument as unknown as string, variables })
     }),
   }),
 });
@@ -277,13 +277,13 @@ export const SubmitRepositoryDocument = new TypedDocumentString(\`
 const injectedRtkApi = alternateApiName.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument unknown as string, variables })
+      query: (variables) => ({ document: CommentDocument as unknown as string, variables })
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument unknown as string, variables })
+      query: (variables) => ({ document: FeedDocument as unknown as string, variables })
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument as unknown as string, variables })
     }),
   }),
 });
@@ -365,13 +365,13 @@ const injectedRtkApi = api.injectEndpoints({
   overrideExisting: module.hot?.status() === "apply",
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument unknown as string, variables })
+      query: (variables) => ({ document: CommentDocument as unknown as string, variables })
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument unknown as string, variables })
+      query: (variables) => ({ document: FeedDocument as unknown as string, variables })
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument as unknown as string, variables })
     }),
   }),
 });
@@ -452,13 +452,13 @@ export const SubmitRepositoryDocument = new TypedDocumentString(\`
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument unknown as string, variables })
+      query: (variables) => ({ document: CommentDocument as unknown as string, variables })
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument unknown as string, variables })
+      query: (variables) => ({ document: FeedDocument as unknown as string, variables })
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument as unknown as string, variables })
     }),
   }),
 });

--- a/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
+++ b/packages/plugins/typescript/rtk-query/tests/__snapshots__/rtk-query.spec.ts.snap
@@ -100,15 +100,15 @@ export const SubmitRepositoryDocument = new TypedDocumentString(\`
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument, variables })
+      query: (variables) => ({ document: CommentDocument unknown as string, variables })
       transformResponse: (response: CommentQuery) => response
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument, variables })
+      query: (variables) => ({ document: FeedDocument unknown as string, variables })
       transformResponse: (response: FeedQuery) => response
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
       transformResponse: (response: SubmitRepositoryMutation) => response
     }),
   }),
@@ -190,13 +190,13 @@ export const SubmitRepositoryDocument = new TypedDocumentString(\`
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument, variables })
+      query: (variables) => ({ document: CommentDocument unknown as string, variables })
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument, variables })
+      query: (variables) => ({ document: FeedDocument unknown as string, variables })
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
     }),
   }),
 });
@@ -277,13 +277,13 @@ export const SubmitRepositoryDocument = new TypedDocumentString(\`
 const injectedRtkApi = alternateApiName.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument, variables })
+      query: (variables) => ({ document: CommentDocument unknown as string, variables })
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument, variables })
+      query: (variables) => ({ document: FeedDocument unknown as string, variables })
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
     }),
   }),
 });
@@ -365,13 +365,13 @@ const injectedRtkApi = api.injectEndpoints({
   overrideExisting: module.hot?.status() === "apply",
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument, variables })
+      query: (variables) => ({ document: CommentDocument unknown as string, variables })
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument, variables })
+      query: (variables) => ({ document: FeedDocument unknown as string, variables })
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
     }),
   }),
 });
@@ -452,100 +452,13 @@ export const SubmitRepositoryDocument = new TypedDocumentString(\`
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument, variables })
+      query: (variables) => ({ document: CommentDocument unknown as string, variables })
     }),
     Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument, variables })
+      query: (variables) => ({ document: FeedDocument unknown as string, variables })
     }),
     submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
-    }),
-  }),
-});
-
-export { injectedRtkApi as api };
-
-
-"
-`;
-
-exports[`RTK Query > Without hooks 2`] = `
-"export class TypedDocumentString<TResult, TVariables>
-  extends String
-  implements DocumentTypeDecoration<TResult, TVariables>
-{
-  __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
-  private value: string;
-  public __meta__?: Record<string, any> | undefined;
-
-  constructor(value: string, __meta__?: Record<string, any> | undefined) {
-    super(value);
-    this.value = value;
-    this.__meta__ = __meta__;
-  }
-
-  override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
-    return this.value;
-  }
-}
-
-export const CommentDocument = new TypedDocumentString(\`
-    query Comment($repoFullName: String!, $limit: Int, $offset: Int) {
-  currentUser {
-    login
-    html_url
-  }
-  entry(repoFullName: $repoFullName) {
-    id
-    postedBy {
-      login
-      html_url
-    }
-    createdAt
-    comments(limit: $limit, offset: $offset) {
-      ...CommentsPageComment
-    }
-    commentCount
-    repository {
-      full_name
-      html_url
-      ... on Repository {
-        description
-        open_issues_count
-        stargazers_count
-      }
-    }
-  }
-}
-    \`);
-export const FeedDocument = new TypedDocumentString(\`
-    query Feed($type: FeedType!, $offset: Int, $limit: Int) {
-  currentUser {
-    login
-  }
-  feed(type: $type, offset: $offset, limit: $limit) {
-    ...FeedEntry
-  }
-}
-    \`);
-export const SubmitRepositoryDocument = new TypedDocumentString(\`
-    mutation submitRepository($repoFullName: String!) {
-  submitRepository(repoFullName: $repoFullName) {
-    createdAt
-  }
-}
-    \`);
-
-const injectedRtkApi = api.injectEndpoints({
-  endpoints: (build) => ({
-    Comment: build.query<CommentQuery, CommentQueryVariables>({
-      query: (variables) => ({ document: CommentDocument, variables })
-    }),
-    Feed: build.query<FeedQuery, FeedQueryVariables>({
-      query: (variables) => ({ document: FeedDocument, variables })
-    }),
-    submitRepository: build.mutation<SubmitRepositoryMutation, SubmitRepositoryMutationVariables>({
-      query: (variables) => ({ document: SubmitRepositoryDocument, variables })
+      query: (variables) => ({ document: SubmitRepositoryDocument unknown as string, variables })
     }),
   }),
 });


### PR DESCRIPTION
## Description

Continuation of https://github.com/dotansimha/graphql-code-generator-community/pull/1496 and https://github.com/dotansimha/graphql-code-generator-community/pull/1497
After releasing, I realised the type may not work because the integration requires `string | DocumentNode` instead of `TypedDocumentNode`

This PR:
- for `typescript-rtk-query`: fixes it by typecasting the document as `string` whilst keeping the original `TypedDocumentNode` as-is, for correct typing at declaration.
- for `typescript-react-query`: wire up `TypedDocumentNode` instead of `string` into generated functions

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1410#issuecomment-4623389873

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
