### PR TITLE
[typescript-react-query] Fix TypedDocumentString not showing up in typescript-react-query when only fragment is used

### DIFF
--- a/.changeset/@graphql-codegen_typescript-react-query-1516-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-react-query-1516-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-react-query": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^7.1.1` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/7.1.1) (from `^7.1.0`, in `dependencies`)

--- a/.changeset/some-owls-invent.md
+++ b/.changeset/some-owls-invent.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Fix TypedDocumentString not being generated when only fragments are available

--- a/packages/plugins/typescript/react-query/package.json
+++ b/packages/plugins/typescript/react-query/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^7.0.1",
-    "@graphql-codegen/visitor-plugin-common": "^7.1.0",
+    "@graphql-codegen/visitor-plugin-common": "^7.1.1",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/react-query/src/index.ts
+++ b/packages/plugins/typescript/react-query/src/index.ts
@@ -29,6 +29,17 @@ export const plugin: PluginFunction<ReactQueryRawPluginConfig, Types.ComplexPlug
   const visitor = new ReactQueryVisitor(schema, allFragments, config, documents);
   const visitorResult = oldVisit(allAst, { leave: visitor });
 
+  const prepend: string[] = [...visitor.getImports()];
+  const content: string[] = [''];
+
+  if (visitor.hasOperations) {
+    prepend.push(visitor.getFetcherImplementation());
+  }
+
+  if (visitor.hasFragments) {
+    content.push(typedDocumentString.template);
+  }
+
   if (visitor.hasOperations) {
     return {
       prepend: [...visitor.getImports(), visitor.getFetcherImplementation()],
@@ -41,13 +52,12 @@ export const plugin: PluginFunction<ReactQueryRawPluginConfig, Types.ComplexPlug
     };
   }
 
+  content.push(visitor.fragments);
+  content.push(...visitorResult.definitions.filter(t => typeof t === 'string'));
+
   return {
-    prepend: [...visitor.getImports()],
-    content: [
-      '',
-      visitor.fragments,
-      ...visitorResult.definitions.filter(t => typeof t === 'string'),
-    ].join('\n'),
+    prepend,
+    content: content.join('\n'),
   };
 };
 

--- a/packages/plugins/typescript/react-query/src/visitor.ts
+++ b/packages/plugins/typescript/react-query/src/visitor.ts
@@ -81,37 +81,41 @@ export class ReactQueryVisitor extends ClientSideBaseVisitor<
     return this._collectedOperations.length > 0;
   }
 
+  public get hasFragments(): boolean {
+    return this._fragments.size > 0;
+  }
+
   public getImports(): string[] {
     const baseImports = super.getImports();
 
-    if (!this.hasOperations) {
-      return baseImports;
+    if (this.hasFragments || this.hasOperations) {
+      const typedDocumentStringPropImport = this._generateImport(
+        typedDocumentString.import,
+        typedDocumentString.import.propName,
+        true,
+      );
+
+      baseImports.push(typedDocumentStringPropImport);
     }
 
-    const hookAndTypeImports = [
-      ...Array.from(this.reactQueryHookIdentifiersInUse),
-      ...Array.from(this.reactQueryOptionsIdentifiersInUse).map(
-        identifier => `${this.config.useTypeImports ? 'type ' : ''}${identifier}`,
-      ),
-    ];
+    if (this.hasOperations) {
+      const hookAndTypeImports = [
+        ...Array.from(this.reactQueryHookIdentifiersInUse),
+        ...Array.from(this.reactQueryOptionsIdentifiersInUse).map(
+          identifier => `${this.config.useTypeImports ? 'type ' : ''}${identifier}`,
+        ),
+      ];
 
-    const moduleName = this.config.reactQueryImportFrom
-      ? this.config.reactQueryImportFrom
-      : this.config.reactQueryVersion <= 3
-        ? 'react-query'
-        : '@tanstack/react-query';
+      const moduleName = this.config.reactQueryImportFrom
+        ? this.config.reactQueryImportFrom
+        : this.config.reactQueryVersion <= 3
+          ? 'react-query'
+          : '@tanstack/react-query';
 
-    const typedDocumentStringPropImport = this._generateImport(
-      typedDocumentString.import,
-      typedDocumentString.import.propName,
-      true,
-    );
+      baseImports.push(`import { ${hookAndTypeImports.join(', ')} } from '${moduleName}';`);
+    }
 
-    return [
-      ...baseImports,
-      typedDocumentStringPropImport,
-      `import { ${hookAndTypeImports.join(', ')} } from '${moduleName}';`,
-    ];
+    return baseImports;
   }
 
   public getFetcherImplementation(): string {

--- a/packages/plugins/typescript/react-query/tests/react-query.fragment.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.fragment.spec.ts
@@ -1,0 +1,51 @@
+import { buildSchema, parse } from 'graphql';
+import { plugin } from '../src/index.js';
+
+describe('React Query - fragments', () => {
+  it('generates TypedDocumentString for fragments correctly', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        say: Something
+      }
+
+      type Something {
+        id: ID!
+      }
+    `);
+
+    const document = parse(/* GraphQL */ `
+      fragment SomethingFrag on Something {
+        id
+      }
+    `);
+
+    const { content } = await plugin(schema, [{ document }], {});
+
+    expect(content).toMatchInlineSnapshot(`
+      "
+      export class TypedDocumentString<TResult, TVariables>
+        extends String
+        implements DocumentTypeDecoration<TResult, TVariables>
+      {
+        __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+        private value: string;
+        public __meta__?: Record<string, any> | undefined;
+
+        constructor(value: string, __meta__?: Record<string, any> | undefined) {
+          super(value);
+          this.value = value;
+          this.__meta__ = __meta__;
+        }
+
+        override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+          return this.value;
+        }
+      }
+      export const SomethingFragFragmentDoc = new TypedDocumentString(\`
+          fragment SomethingFrag on Something {
+        id
+      }
+          \`, {"fragmentName":"SomethingFrag"});"
+    `);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,10 +1581,10 @@
     parse-filepath "^1.0.2"
     tslib "^2.8.0"
 
-"@graphql-codegen/visitor-plugin-common@^7.0.0", "@graphql-codegen/visitor-plugin-common@^7.0.3", "@graphql-codegen/visitor-plugin-common@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.1.0.tgz#73aaf4aa2ce72255e687348d311f8aa26749dfb1"
-  integrity sha512-CO4fJyflbYBuAwbQD16bAuWBIXkz9il3JwyC+pQzXh8NJ+BZZDXmYjmVeGeJuoMUIQDb+CNo2thCU0bFFamAkg==
+"@graphql-codegen/visitor-plugin-common@^7.0.0", "@graphql-codegen/visitor-plugin-common@^7.0.3", "@graphql-codegen/visitor-plugin-common@^7.1.0", "@graphql-codegen/visitor-plugin-common@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.1.1.tgz#15686db8ee59f6e7e7160e24691b8b1bb76bdf1a"
+  integrity sha512-MGZBXmp1i+45aw0GRH+BBpOI8ic8Ay/OJ5zGeZH6SLhSB/uxhwTjjOxkxazR8dqzKTbk7hFPhIXcXhkFP2v2eA==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^7.0.1"
     "@graphql-tools/optimize" "^2.0.0"


### PR DESCRIPTION
## Description

This PR fixes TypedDocumentString not showing up in typescript-react-query when only fragment is used

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1410#issuecomment-4725163730

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)