### PR TITLE
[typescript-rtk-query][typescript-react-query] Fix missing import in documents when only fragment exists

### DIFF
--- a/.changeset/@graphql-codegen_typescript-rtk-query-1522-dependencies.md
+++ b/.changeset/@graphql-codegen_typescript-rtk-query-1522-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/typescript-rtk-query": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-codegen/visitor-plugin-common@^7.1.1` ↗︎](https://www.npmjs.com/package/@graphql-codegen/visitor-plugin-common/v/7.1.1) (from `^7.1.0`, in `dependencies`)

--- a/.changeset/crisp-jobs-wave.md
+++ b/.changeset/crisp-jobs-wave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-react-query': patch
+---
+
+Remove unncessary early return. No functional change.

--- a/.changeset/humble-apes-train.md
+++ b/.changeset/humble-apes-train.md
@@ -1,0 +1,5 @@
+---
+'@graphql-codegen/typescript-rtk-query': patch
+---
+
+Fix missing type import if document file only contains a fragment

--- a/packages/plugins/typescript/react-query/src/index.ts
+++ b/packages/plugins/typescript/react-query/src/index.ts
@@ -36,20 +36,8 @@ export const plugin: PluginFunction<ReactQueryRawPluginConfig, Types.ComplexPlug
     prepend.push(visitor.getFetcherImplementation());
   }
 
-  if (visitor.hasFragments) {
+  if (visitor.hasFragments || visitor.hasOperations) {
     content.push(typedDocumentString.template);
-  }
-
-  if (visitor.hasOperations) {
-    return {
-      prepend: [...visitor.getImports(), visitor.getFetcherImplementation()],
-      content: [
-        '',
-        typedDocumentString.template,
-        visitor.fragments,
-        ...visitorResult.definitions.filter(t => typeof t === 'string'),
-      ].join('\n'),
-    };
   }
 
   content.push(visitor.fragments);

--- a/packages/plugins/typescript/react-query/tests/react-query.fragment.spec.ts
+++ b/packages/plugins/typescript/react-query/tests/react-query.fragment.spec.ts
@@ -19,10 +19,11 @@ describe('React Query - fragments', () => {
       }
     `);
 
-    const { content } = await plugin(schema, [{ document }], {});
+    const result = await plugin(schema, [{ document }], {});
 
-    expect(content).toMatchInlineSnapshot(`
-      "
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "content": "
       export class TypedDocumentString<TResult, TVariables>
         extends String
         implements DocumentTypeDecoration<TResult, TVariables>
@@ -45,7 +46,11 @@ describe('React Query - fragments', () => {
           fragment SomethingFrag on Something {
         id
       }
-          \`, {"fragmentName":"SomethingFrag"});"
+          \`, {"fragmentName":"SomethingFrag"});",
+        "prepend": [
+          "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
+        ],
+      }
     `);
   });
 });

--- a/packages/plugins/typescript/rtk-query/package.json
+++ b/packages/plugins/typescript/rtk-query/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^7.0.1",
-    "@graphql-codegen/visitor-plugin-common": "^7.1.0",
+    "@graphql-codegen/visitor-plugin-common": "^7.1.1",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/rtk-query/src/visitor.ts
+++ b/packages/plugins/typescript/rtk-query/src/visitor.ts
@@ -49,24 +49,30 @@ export class RTKQueryVisitor extends ClientSideBaseVisitor<
     return this._collectedOperations.length > 0;
   }
 
+  public get hasFragments(): boolean {
+    return this._fragments.size > 0;
+  }
+
   public getImports(): string[] {
     const baseImports = super.getImports();
 
-    if (!this.hasOperations) {
-      return baseImports;
+    if (this.hasFragments || this.hasOperations) {
+      const typedDocumentStringPropImport = this._generateImport(
+        typedDocumentString.import,
+        typedDocumentString.import.propName,
+        true,
+      );
+
+      baseImports.push(typedDocumentStringPropImport);
     }
 
-    const typedDocumentStringPropImport = this._generateImport(
-      typedDocumentString.import,
-      typedDocumentString.import.propName,
-      true,
-    );
+    if (this.hasOperations) {
+      baseImports.push(
+        `import { ${this.config.importBaseApiAlternateName} } from '${this.config.importBaseApiFrom}';`,
+      );
+    }
 
-    return [
-      ...baseImports,
-      typedDocumentStringPropImport,
-      `import { ${this.config.importBaseApiAlternateName} } from '${this.config.importBaseApiFrom}';`,
-    ];
+    return baseImports;
   }
 
   public getInjectCall() {

--- a/packages/plugins/typescript/rtk-query/tests/rtk-query.fragment.spec.ts
+++ b/packages/plugins/typescript/rtk-query/tests/rtk-query.fragment.spec.ts
@@ -47,7 +47,9 @@ describe('RTK Query - fragments', () => {
       }
           \`, {"fragmentName":"SomethingFrag"});
       ",
-        "prepend": [],
+        "prepend": [
+          "import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';",
+        ],
       }
     `);
   });

--- a/packages/plugins/typescript/rtk-query/tests/rtk-query.fragment.spec.ts
+++ b/packages/plugins/typescript/rtk-query/tests/rtk-query.fragment.spec.ts
@@ -1,0 +1,54 @@
+import { buildSchema, parse } from 'graphql';
+import { plugin } from '../src/index.js';
+
+describe('RTK Query - fragments', () => {
+  it('generates TypedDocumentString for fragments correctly', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        say: Something
+      }
+
+      type Something {
+        id: ID!
+      }
+    `);
+
+    const document = parse(/* GraphQL */ `
+      fragment SomethingFrag on Something {
+        id
+      }
+    `);
+
+    const result = await plugin(schema, [{ document }], { importBaseApiFrom: './api' });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "content": "export class TypedDocumentString<TResult, TVariables>
+        extends String
+        implements DocumentTypeDecoration<TResult, TVariables>
+      {
+        __apiType?: NonNullable<DocumentTypeDecoration<TResult, TVariables>['__apiType']>;
+        private value: string;
+        public __meta__?: Record<string, any> | undefined;
+
+        constructor(value: string, __meta__?: Record<string, any> | undefined) {
+          super(value);
+          this.value = value;
+          this.__meta__ = __meta__;
+        }
+
+        override toString(): string & DocumentTypeDecoration<TResult, TVariables> {
+          return this.value;
+        }
+      }
+      export const SomethingFragFragmentDoc = new TypedDocumentString(\`
+          fragment SomethingFrag on Something {
+        id
+      }
+          \`, {"fragmentName":"SomethingFrag"});
+      ",
+        "prepend": [],
+      }
+    `);
+  });
+});


### PR DESCRIPTION
## Description

This PR is a continuation of https://github.com/dotansimha/graphql-code-generator-community/pull/1516 when only fragments are found in documents:
- Fix extraneous early return in `typescript-react-query`
- Fix missing `DocumentTypeDecoration` import  in `typescript-rtk-query`

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1410#issuecomment-4777250143