### PR TITLE
[near-operation-file-preset] Fix missing fragment document imports for nested fragments (graphQLTag)

### DIFF
--- a/.changeset/near-operation-file-nested-fragment-imports.md
+++ b/.changeset/near-operation-file-nested-fragment-imports.md
@@ -1,0 +1,5 @@
+---
+"@graphql-codegen/near-operation-file-preset": patch
+---
+
+Fix fragment `*Doc` imports for transitively-nested fragments in `documentMode: graphQLTag`. Since visitor-plugin-common v7 a graphQLTag operation inlines every fragment it transitively spreads, so the operation file now imports the `*Doc` of fragments reached only through another fragment (previously missing — `Cannot find name 'XFragmentDoc'`), while fragment files no longer emit unused fragment `*Doc` imports.

--- a/.changeset/near-operation-file-nested-fragment-imports.md
+++ b/.changeset/near-operation-file-nested-fragment-imports.md
@@ -1,0 +1,13 @@
+---
+'@graphql-codegen/near-operation-file-preset': patch
+---
+
+Fix fragment `*Doc` imports for transitively-nested fragments in `documentMode: graphQLTag`.
+
+Since `visitor-plugin-common` v7, a `graphQLTag` operation inlines every fragment it transitively
+spreads, so the operation file now imports the `*Doc` of fragments reached only through another
+fragment. Previously these were missing, producing `Cannot find name 'XFragmentDoc'`. Fragment files
+correspondingly no longer emit fragment `*Doc` imports they don't use.
+
+Requires `@graphql-codegen/visitor-plugin-common` `^7.2.2` — earlier v7 releases emit an invalid
+`import * from '...'` statement for fragment files whose imports are all elided.

--- a/.changeset/react-apollo-stencil-apollo-common-v7.md
+++ b/.changeset/react-apollo-stencil-apollo-common-v7.md
@@ -1,0 +1,11 @@
+---
+'@graphql-codegen/typescript-react-apollo': major
+'@graphql-codegen/typescript-stencil-apollo': major
+---
+
+Update GraphQL Codegen common packages to latest (`@graphql-codegen/visitor-plugin-common` v7).
+
+This changes the shape of generated documents: a fragment's `*Doc` no longer interpolates the
+fragments it spreads, and each operation document instead interpolates every fragment it
+transitively spreads. Generated output is equivalent, but any code or snapshot asserting on the
+previous interpolation layout needs updating.

--- a/dev-test/githunt/__generated__/feed-entry.fragment.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed-entry.fragment.stencil-component.tsx
@@ -1,6 +1,4 @@
 import gql from 'graphql-tag';
-import { RepoInfoFragmentDoc } from './repo-info.fragment.stencil-component.js';
-import { VoteButtonsFragmentDoc } from './vote-buttons.fragment.stencil-component.js';
 
 declare global {
   export type FeedEntryFragment = {
@@ -37,6 +35,4 @@ export const FeedEntryFragmentDoc = gql`
     ...VoteButtons
     ...RepoInfo
   }
-  ${VoteButtonsFragmentDoc}
-  ${RepoInfoFragmentDoc}
 `;

--- a/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
+++ b/dev-test/githunt/__generated__/feed.query.stencil-component.tsx
@@ -1,5 +1,7 @@
 import gql from 'graphql-tag';
 import { FeedEntryFragmentDoc } from './feed-entry.fragment.stencil-component.js';
+import { RepoInfoFragmentDoc } from './repo-info.fragment.stencil-component.js';
+import { VoteButtonsFragmentDoc } from './vote-buttons.fragment.stencil-component.js';
 import 'stencil-apollo';
 import { Component, h, Prop } from '@stencil/core';
 
@@ -44,6 +46,8 @@ const FeedDocument = gql`
     }
   }
   ${FeedEntryFragmentDoc}
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
 `;
 
 @Component({

--- a/dev-test/githunt/types.reactApollo.customSuffix.tsx
+++ b/dev-test/githunt/types.reactApollo.customSuffix.tsx
@@ -392,8 +392,6 @@ export const FeedEntryFragmentDoc = gql`
     ...VoteButtons
     ...RepoInfo
   }
-  ${VoteButtonsFragmentDoc}
-  ${RepoInfoFragmentDoc}
 `;
 export const OnCommentAddedDocument = gql`
   subscription onCommentAdded($repoFullName: String!) {
@@ -636,6 +634,8 @@ export const FeedDocument = gql`
     }
   }
   ${FeedEntryFragmentDoc}
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
 `;
 
 /**

--- a/dev-test/githunt/types.reactApollo.hooks.tsx
+++ b/dev-test/githunt/types.reactApollo.hooks.tsx
@@ -392,8 +392,6 @@ export const FeedEntryFragmentDoc = gql`
     ...VoteButtons
     ...RepoInfo
   }
-  ${VoteButtonsFragmentDoc}
-  ${RepoInfoFragmentDoc}
 `;
 export function useCommentsPageCommentFragment<F = { id: string }>(identifiers: F) {
   return Apollo.useFragment<CommentsPageCommentFragment>({
@@ -673,6 +671,8 @@ export const FeedDocument = gql`
     }
   }
   ${FeedEntryFragmentDoc}
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
 `;
 
 /**

--- a/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
+++ b/dev-test/githunt/types.reactApollo.preResolveTypes.tsx
@@ -392,8 +392,6 @@ export const FeedEntryFragmentDoc = gql`
     ...VoteButtons
     ...RepoInfo
   }
-  ${VoteButtonsFragmentDoc}
-  ${RepoInfoFragmentDoc}
 `;
 export const OnCommentAddedDocument = gql`
   subscription onCommentAdded($repoFullName: String!) {
@@ -627,6 +625,8 @@ export const FeedDocument = gql`
     }
   }
   ${FeedEntryFragmentDoc}
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
 `;
 
 /**

--- a/dev-test/githunt/types.reactApollo.tsx
+++ b/dev-test/githunt/types.reactApollo.tsx
@@ -392,8 +392,6 @@ export const FeedEntryFragmentDoc = gql`
     ...VoteButtons
     ...RepoInfo
   }
-  ${VoteButtonsFragmentDoc}
-  ${RepoInfoFragmentDoc}
 `;
 export const OnCommentAddedDocument = gql`
   subscription onCommentAdded($repoFullName: String!) {
@@ -627,6 +625,8 @@ export const FeedDocument = gql`
     }
   }
   ${FeedEntryFragmentDoc}
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
 `;
 
 /**

--- a/dev-test/githunt/types.reactApollo.v2.tsx
+++ b/dev-test/githunt/types.reactApollo.v2.tsx
@@ -393,8 +393,6 @@ export const FeedEntryFragmentDoc = gql`
     ...VoteButtons
     ...RepoInfo
   }
-  ${VoteButtonsFragmentDoc}
-  ${RepoInfoFragmentDoc}
 `;
 export const OnCommentAddedDocument = gql`
   subscription onCommentAdded($repoFullName: String!) {
@@ -641,6 +639,8 @@ export const FeedDocument = gql`
     }
   }
   ${FeedEntryFragmentDoc}
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
 `;
 
 /**

--- a/dev-test/githunt/types.stencilApollo.tsx
+++ b/dev-test/githunt/types.stencilApollo.tsx
@@ -392,8 +392,6 @@ export const FeedEntryFragmentDoc = gql`
     ...VoteButtons
     ...RepoInfo
   }
-  ${VoteButtonsFragmentDoc}
-  ${RepoInfoFragmentDoc}
 `;
 export const OnCommentAddedDocument = gql`
   subscription onCommentAdded($repoFullName: String!) {
@@ -504,6 +502,8 @@ export const FeedDocument = gql`
     }
   }
   ${FeedEntryFragmentDoc}
+  ${VoteButtonsFragmentDoc}
+  ${RepoInfoFragmentDoc}
 `;
 
 export type FeedProps = {

--- a/packages/plugins/typescript/react-apollo/package.json
+++ b/packages/plugins/typescript/react-apollo/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^6.3.0",
-    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^7.2.2",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/plugins/typescript/react-apollo/src/visitor.ts
+++ b/packages/plugins/typescript/react-apollo/src/visitor.ts
@@ -603,7 +603,7 @@ export function use${suspenseOperationName}(baseOptions?: ${this.getApolloReactH
   public get fragments(): string {
     const fragments = super.fragments;
 
-    if (this['_fragments'].length === 0 || !this.config.withFragmentHooks) {
+    if (this['_fragments'].size === 0 || !this.config.withFragmentHooks) {
       return fragments;
     }
 

--- a/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
+++ b/packages/plugins/typescript/react-apollo/tests/react-apollo.spec.ts
@@ -260,7 +260,8 @@ describe('React Apollo', () => {
       ...Feed
     }
   }
-      \${FeedFragmentDoc}\`;`);
+      \${FeedFragmentDoc}
+\${RepoFieldsFragmentDoc}\`;`);
     });
 
     it('Issue #2742 - Incorrect import prefix', async () => {
@@ -737,7 +738,7 @@ fragment FeedWithRepository on Entry {
     ...RepositoryWithOwner
   }
 }
-\${RepositoryWithOwnerFragmentDoc}\`;`);
+\`;`);
       expect(content.content)
         .toBeSimilarStringTo(`export const RepositoryWithOwnerFragmentDoc = gql\`
 fragment RepositoryWithOwner on Repository {
@@ -755,7 +756,8 @@ query MyFeed {
     ...FeedWithRepository
   }
 }
-\${FeedWithRepositoryFragmentDoc}\`;`);
+\${FeedWithRepositoryFragmentDoc}
+\${RepositoryWithOwnerFragmentDoc}\`;`);
       await validateTypeScript(content, schema, docs, {});
     });
 

--- a/packages/plugins/typescript/stencil-apollo/package.json
+++ b/packages/plugins/typescript/stencil-apollo/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^6.3.0",
-    "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+    "@graphql-codegen/visitor-plugin-common": "^7.2.2",
     "auto-bind": "~4.0.0",
     "change-case-all": "1.0.15",
     "tslib": "^2.8.1"

--- a/packages/presets/near-operation-file/package.json
+++ b/packages/presets/near-operation-file/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@graphql-codegen/add": "^7.0.0",
     "@graphql-codegen/plugin-helpers": "^7.0.0",
-    "@graphql-codegen/visitor-plugin-common": "^7.0.0",
+    "@graphql-codegen/visitor-plugin-common": "^7.2.2",
     "@graphql-tools/utils": "^11.0.0",
     "parse-filepath": "^1.0.2",
     "tslib": "^2.8.1"

--- a/packages/presets/near-operation-file/src/fragment-resolver.ts
+++ b/packages/presets/near-operation-file/src/fragment-resolver.ts
@@ -3,6 +3,7 @@ import { Types } from '@graphql-codegen/plugin-helpers';
 import {
   BaseVisitor,
   buildScalarsFromConfig,
+  DocumentMode,
   FragmentImport,
   getConfigValue,
   getPossibleTypes,
@@ -27,60 +28,52 @@ export type FragmentRegistry = {
     filePath: string;
     onType: string;
     node: FragmentDefinitionNode;
-    imports: Array<FragmentImport>;
     possibleTypes: string[];
   };
 };
 
 /**
- * Creates fragment imports based on possible types and usage
+ * Creates a fragment's type imports based on possible types and usage
  */
-function createFragmentImports(
+function createFragmentTypeImports(
   baseVisitor: BaseVisitor<RawConfig, NearOperationFileParsedConfig>,
   fragmentName: string,
   possibleTypes: string[],
   usedTypes?: string[],
 ): Array<FragmentImport> {
-  const fragmentImports: Array<FragmentImport> = [];
-
-  // Always include the document import
-  fragmentImports.push({
-    name: baseVisitor.getFragmentVariableName(fragmentName),
-    kind: 'document',
-  });
-
   const fragmentSuffix = baseVisitor.getFragmentSuffix(fragmentName);
 
   if (possibleTypes.length === 1) {
-    fragmentImports.push({
-      name: baseVisitor.convertName(fragmentName, {
-        useTypesPrefix: true,
-        suffix: fragmentSuffix,
-      }),
-      kind: 'type',
-    });
-  } else if (possibleTypes.length > 0) {
-    const typesToImport = usedTypes && usedTypes.length > 0 ? usedTypes : possibleTypes;
-
-    typesToImport.forEach(typeName => {
-      fragmentImports.push({
+    return [
+      {
         name: baseVisitor.convertName(fragmentName, {
           useTypesPrefix: true,
-          suffix: `_${typeName}` + (fragmentSuffix.length > 0 ? `_${fragmentSuffix}` : ''),
+          suffix: fragmentSuffix,
         }),
         kind: 'type',
-      });
-    });
+      },
+    ];
   }
 
-  return fragmentImports;
+  if (possibleTypes.length > 0) {
+    const typesToImport = usedTypes && usedTypes.length > 0 ? usedTypes : possibleTypes;
+
+    return typesToImport.map(typeName => ({
+      name: baseVisitor.convertName(fragmentName, {
+        useTypesPrefix: true,
+        suffix: `_${typeName}` + (fragmentSuffix.length > 0 ? `_${fragmentSuffix}` : ''),
+      }),
+      kind: 'type',
+    }));
+  }
+
+  return [];
 }
 
 /**
- * Used by `buildFragmentResolver` to build a mapping of fragmentNames to paths, importNames, and other useful info
+ * Used by `buildFragmentResolver` to build a mapping of fragmentNames to paths, nodes, and other useful info
  */
 function buildFragmentRegistry(
-  baseVisitor: BaseVisitor<RawConfig, NearOperationFileParsedConfig>,
   { generateFilePath }: DocumentImportResolverOptions,
   { documents }: Types.PresetFnArgs<{}>,
   schemaObject: GraphQLSchema,
@@ -108,7 +101,6 @@ function buildFragmentRegistry(
       const fragmentName = fragment.name.value;
       const possibleTypes = getPossibleTypes(schemaObject, schemaType);
       const possibleTypeNames = possibleTypes.map(t => t.name);
-      const imports = createFragmentImports(baseVisitor, fragment.name.value, possibleTypeNames);
 
       if (prev[fragmentName] && print(fragment) !== print(prev[fragmentName].node)) {
         duplicateFragmentNames.push(fragmentName);
@@ -116,7 +108,6 @@ function buildFragmentRegistry(
 
       prev[fragmentName] = {
         filePath,
-        imports,
         onType: fragment.typeCondition.name.value,
         node: fragment,
         possibleTypes: possibleTypeNames,
@@ -162,21 +153,20 @@ export default function buildFragmentResolver<T>(
 ) {
   const { config } = presetOptions;
   const baseVisitor = createBaseVisitor(config, schemaObject);
-  const fragmentRegistry = buildFragmentRegistry(
-    baseVisitor,
-    collectorOptions,
-    presetOptions,
-    schemaObject,
-  );
+  const fragmentRegistry = buildFragmentRegistry(collectorOptions, presetOptions, schemaObject);
   const { baseOutputDir } = presetOptions;
   const { baseDir, typesImport } = collectorOptions;
 
   function resolveFragments(generatedFilePath: string, documentFileContent: DocumentNode) {
-    const { fragmentsInUse, usedFragmentTypes } = analyzeFragmentUsage(
+    const { fragmentsInUse, usedFragmentTypes, operationFragments } = analyzeFragmentUsage(
       documentFileContent,
       fragmentRegistry,
       schemaObject,
     );
+
+    // graphQLTag operations inline every fragment they transitively spread
+    const { documentMode = DocumentMode.graphQLTag } = config;
+    const isGraphQLTagMode = documentMode === DocumentMode.graphQLTag;
 
     const externalFragments: LoadedFragment<{ level: number }>[] = [];
     const fragmentFileImports: { [fragmentFile: string]: Array<FragmentImport> } = {};
@@ -186,29 +176,35 @@ export default function buildFragmentResolver<T>(
 
       if (!fragmentDetails) continue;
 
-      // add top level references to the import object
-      // we don't check or global namespace because the calling config can do so
-      if (
-        level === 0 ||
-        (dedupeFragments &&
-          ['OperationDefinition', 'FragmentDefinition'].includes(
-            documentFileContent.definitions[0].kind,
-          ))
-      ) {
-        if (fragmentDetails.filePath !== generatedFilePath) {
-          // don't emit imports to same location
-          const usedTypesForFragment = usedFragmentTypes[fragmentName] || [];
-          const filteredImports = createFragmentImports(
-            baseVisitor,
-            fragmentName,
-            fragmentDetails.possibleTypes,
-            usedTypesForFragment,
-          );
+      // don't emit imports to the same location
+      if (fragmentDetails.filePath !== generatedFilePath) {
+        const imports: FragmentImport[] = [];
+        const isSpreadDirectly = level === 0 || dedupeFragments;
 
-          if (!fragmentFileImports[fragmentDetails.filePath]) {
-            fragmentFileImports[fragmentDetails.filePath] = [];
-          }
-          fragmentFileImports[fragmentDetails.filePath].push(...filteredImports);
+        const needsDocument = isGraphQLTagMode
+          ? operationFragments.has(fragmentName)
+          : isSpreadDirectly;
+
+        if (needsDocument) {
+          imports.push({
+            name: baseVisitor.getFragmentVariableName(fragmentName),
+            kind: 'document',
+          });
+        }
+
+        if (isSpreadDirectly) {
+          imports.push(
+            ...createFragmentTypeImports(
+              baseVisitor,
+              fragmentName,
+              fragmentDetails.possibleTypes,
+              usedFragmentTypes[fragmentName] || [],
+            ),
+          );
+        }
+
+        if (imports.length > 0) {
+          (fragmentFileImports[fragmentDetails.filePath] ??= []).push(...imports);
         }
       }
 

--- a/packages/presets/near-operation-file/src/utils.ts
+++ b/packages/presets/near-operation-file/src/utils.ts
@@ -8,6 +8,8 @@ import {
   isInterfaceType,
   isObjectType,
   isUnionType,
+  Kind,
+  OperationDefinitionNode,
   SelectionSetNode,
   TypeInfo,
   visit,
@@ -43,6 +45,7 @@ export function analyzeFragmentUsage(
 ): {
   fragmentsInUse: { [fragmentName: string]: number };
   usedFragmentTypes: { [fragmentName: string]: string[] };
+  operationFragments: Set<string>;
 } {
   const localFragments = getLocalFragments(documentNode);
 
@@ -60,26 +63,64 @@ export function analyzeFragmentUsage(
     fragmentsInUse,
   );
 
-  return { fragmentsInUse, usedFragmentTypes };
+  const operationFragments = collectOperationFragments(
+    documentNode,
+    fragmentRegistry,
+    localFragments,
+  );
+
+  return { fragmentsInUse, usedFragmentTypes, operationFragments };
 }
 
 /**
- * Get all fragment definitions that are local to this document
+ * External fragments transitively reachable from the document's operations (graphQLTag operations
+ * interpolate all of these). Steps through local fragments too, since an operation may reach an
+ * external fragment via a local one.
  */
-function getLocalFragments(documentNode: DocumentNode): Set<string> {
-  const localFragments = new Set<string>();
+function collectOperationFragments(
+  documentNode: DocumentNode,
+  fragmentRegistry: FragmentRegistry,
+  localFragments: Map<string, FragmentDefinitionNode>,
+): Set<string> {
+  const reachable = new Set<string>();
+  const visited = new Set<string>();
+
+  const collect = (node: OperationDefinitionNode | FragmentDefinitionNode): void => {
+    visit(node, {
+      FragmentSpread: ({ name: { value } }) => {
+        if (fragmentRegistry[value]) reachable.add(value);
+        if (visited.has(value)) return;
+        visited.add(value);
+        const fragmentNode = fragmentRegistry[value]?.node ?? localFragments.get(value);
+        if (fragmentNode) collect(fragmentNode);
+      },
+    });
+  };
+
+  for (const definition of documentNode.definitions) {
+    if (definition.kind === Kind.OPERATION_DEFINITION) collect(definition);
+  }
+
+  return reachable;
+}
+
+/**
+ * Get all fragment definitions that are local to this document, keyed by name
+ */
+function getLocalFragments(documentNode: DocumentNode): Map<string, FragmentDefinitionNode> {
+  const localFragments = new Map<string, FragmentDefinitionNode>();
   visit(documentNode, {
     FragmentDefinition: node => {
-      localFragments.add(node.name.value);
+      localFragments.set(node.name.value, node);
     },
   });
   return localFragments;
 }
 
-export function extractExternalFragmentsInUse(
+function extractExternalFragmentsInUse(
   documentNode: DocumentNode | FragmentDefinitionNode,
   fragmentNameToFile: FragmentRegistry,
-  localFragment: Set<string>,
+  localFragment: Map<string, FragmentDefinitionNode>,
   result: { [fragmentName: string]: number } = {},
   level = 0,
 ): { [fragmentName: string]: number } {
@@ -115,7 +156,7 @@ function analyzeFragmentTypeUsage(
   documentNode: DocumentNode,
   fragmentRegistry: FragmentRegistry,
   schema: GraphQLSchema,
-  localFragments: Set<string>,
+  localFragments: Map<string, FragmentDefinitionNode>,
   fragmentsInUse: { [fragmentName: string]: number },
 ): { [fragmentName: string]: string[] } {
   const usedFragmentTypes: { [fragmentName: string]: Set<string> } = {};
@@ -168,7 +209,7 @@ function analyzeSelectionSetTypeContext(
   usedFragmentTypes: { [fragmentName: string]: Set<string> },
   fragmentRegistry: FragmentRegistry,
   schema: GraphQLSchema,
-  localFragments: Set<string>,
+  localFragments: Map<string, FragmentDefinitionNode>,
 ): void {
   const { spreads, inlines } = separateSelectionSet(selectionSet.selections);
 

--- a/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
+++ b/packages/presets/near-operation-file/tests/near-operation-file.spec.ts
@@ -319,6 +319,162 @@ describe('near-operation-file preset', () => {
       );
     });
 
+    it("Should add import to external fragment when it's in use (transitively nested fragment)", async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        schema {
+          query: Query
+        }
+
+        type Query {
+          list: [Book]
+        }
+
+        type Book {
+          id: ID!
+          title: String!
+          pages: [Page!]!
+        }
+
+        type Page {
+          id: ID!
+          number: Int!
+        }
+      `);
+
+      const result = await executePreset({
+        baseOutputDir: './src/',
+        config: {},
+        presetConfig: {
+          cwd: '/some/deep/path',
+          baseTypesPath: 'types.ts',
+        },
+        schemaAst: testSchema,
+        schema: getCachedDocumentNodeFromSchema(testSchema),
+        documents: [
+          {
+            location: '/some/deep/path/src/graphql/queries.graphql',
+            document: parse(/* GraphQL */ `
+              query List {
+                list {
+                  ...Book
+                }
+              }
+            `),
+          },
+          {
+            location: '/some/deep/path/src/graphql/book-fragment.graphql',
+            document: parse(/* GraphQL */ `
+              fragment Book on Book {
+                id
+                title
+                pages {
+                  ...Page
+                }
+              }
+            `),
+          },
+          {
+            location: '/some/deep/path/src/graphql/page-fragment.graphql',
+            document: parse(/* GraphQL */ `
+              fragment Page on Page {
+                id
+                number
+              }
+            `),
+          },
+        ],
+        plugins: [{ 'typescript-react-apollo': {} }],
+        pluginMap: { 'typescript-react-apollo': {} as any },
+      });
+
+      expect(result[0].filename).toContain('queries.generated.ts');
+      expect(getFragmentImportsFromResult(result)).toContain(
+        `import { BookFragmentDoc, BookFragment } from './book-fragment.generated';`,
+      );
+      expect(getFragmentImportsFromResult(result)).toContain(
+        `import { PageFragmentDoc } from './page-fragment.generated';`,
+      );
+    });
+
+    it('dedupeFragments: flattens nested fragments into the operation file (imports their type too)', async () => {
+      const testSchema = buildSchema(/* GraphQL */ `
+        schema {
+          query: Query
+        }
+
+        type Query {
+          list: [Book]
+        }
+
+        type Book {
+          id: ID!
+          title: String!
+          pages: [Page!]!
+        }
+
+        type Page {
+          id: ID!
+          number: Int!
+        }
+      `);
+
+      const documents = [
+        {
+          location: '/some/deep/path/src/graphql/queries.graphql',
+          document: parse(/* GraphQL */ `
+            query List {
+              list {
+                ...Book
+              }
+            }
+          `),
+        },
+        {
+          location: '/some/deep/path/src/graphql/book-fragment.graphql',
+          document: parse(/* GraphQL */ `
+            fragment Book on Book {
+              id
+              title
+              pages {
+                ...Page
+              }
+            }
+          `),
+        },
+        {
+          location: '/some/deep/path/src/graphql/page-fragment.graphql',
+          document: parse(/* GraphQL */ `
+            fragment Page on Page {
+              id
+              number
+            }
+          `),
+        },
+      ];
+
+      const run = (dedupeFragments: boolean) =>
+        executePreset({
+          baseOutputDir: './src/',
+          config: { dedupeFragments },
+          presetConfig: { cwd: '/some/deep/path', baseTypesPath: 'types.ts' },
+          schemaAst: testSchema,
+          schema: getCachedDocumentNodeFromSchema(testSchema),
+          documents,
+          plugins: [{ 'typescript-react-apollo': {} }],
+          pluginMap: { 'typescript-react-apollo': {} as any },
+        });
+
+      const withoutDedupe = getFragmentImportsFromResult(await run(false));
+      expect(withoutDedupe).toContain(
+        `import { PageFragmentDoc } from './page-fragment.generated';`,
+      );
+
+      const withDedupe = getFragmentImportsFromResult(await run(true));
+      expect(withDedupe).toContain(
+        `import { PageFragmentDoc, PageFragment } from './page-fragment.generated';`,
+      );
+    });
+
     it('#2365 - Should not add Fragment suffix to import identifier when dedupeOperationSuffix: true', async () => {
       const result = await executePreset({
         baseOutputDir: './src/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,7 +1881,7 @@
     parse-filepath "^1.0.2"
     tslib "^2.8.0"
 
-"@graphql-codegen/visitor-plugin-common@^7.0.0", "@graphql-codegen/visitor-plugin-common@^7.1.1", "@graphql-codegen/visitor-plugin-common@^7.2.0", "@graphql-codegen/visitor-plugin-common@^7.2.2":
+"@graphql-codegen/visitor-plugin-common@^7.1.1", "@graphql-codegen/visitor-plugin-common@^7.2.0", "@graphql-codegen/visitor-plugin-common@^7.2.2":
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.2.5.tgz#e33efe3f29a455b9d69cd695aadb97f41161e26f"
   integrity sha512-hqOemBp0Ue+WSmk8EDcKP+lghuLC2zsI+jHzSUuoffTZnEN2qZH4VP2C9c1fVd2yy6v+YQiiObOarTMaqF4q9w==


### PR DESCRIPTION
## Description

Since `visitor-plugin-common` v7, in `documentMode: graphQLTag` (default) an **operation** document inlines every fragment it *transitively* spreads, while a **fragment** document inlines nothing. The preset still imports `*Doc`s by direct-spread (`level === 0`), so:

- operation files **miss** the `*Doc` of fragments reached through another fragment → `Cannot find name 'XFragmentDoc'`;
- fragment files **import** `*Doc`s they no longer interpolate → unused imports.

## Reproduction

`query List { list { ...Book } }`, `fragment Book on Book { pages { ...Page } }`, `fragment Page on Page { id }` — each in its own file.

```ts
// queries.generated.ts
import { BookFragmentDoc } from './book-fragment.generated';
// ❌ missing: PageFragmentDoc
export const ListDocument = gql`query List{list{...Book}} ${BookFragmentDoc} ${PageFragmentDoc}`; // PageFragmentDoc undefined
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added new unit tests and ran the fixed version against our codebase with 100s of GraphQL queries

## Notes
I have taken some liberty in trimming some code paths that are no longer used, which coincidentally happens to be my code from across the years