### PR TITLE
Update import-types preset to not use types from typescript-operations

### DIFF
--- a/packages/presets/import-types/src/index.ts
+++ b/packages/presets/import-types/src/index.ts
@@ -16,7 +16,7 @@ export type ImportTypesConfig = {
    *    generates: {
    *      'path/to/file.ts': {
    *        preset: 'import-types',
-   *        plugins: ['typescript-operations'],
+   *        plugins: ['typescript-resolvers'],
    *        presetConfig: {
    *          typesPath: 'types.ts'
    *        },
@@ -40,7 +40,7 @@ export type ImportTypesConfig = {
    *    generates: {
    *      'path/to/file.ts': {
    *        preset: 'import-types',
-   *        plugins: ['typescript-operations'],
+   *        plugins: ['typescript-resolvers'],
    *        presetConfig: {
    *          typesPath: 'types.ts',
    *          importTypesNamespace: 'SchemaTypes',


### PR DESCRIPTION
## Description

Do not use `typescript-operations` as an example for `import-types` preset. 
`typescript-resolvers` is a good replacement though, as it is often used with `typescript-resolvers`

Related https://github.com/dotansimha/graphql-code-generator-community/issues/1488

## Type of change

- [x] Documentation update

